### PR TITLE
Add Claude settings with session start hook configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun x gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a `.claude/settings.json` configuration file that sets up a session start hook to automatically run the GitHub setup hooks command.

## Changes
- Added `.claude/settings.json` with hook configuration
  - Configured `SessionStart` hook to execute `bun x gh-setup-hooks` command
  - Set command timeout to 120 seconds to allow sufficient time for setup completion

## Details
The new settings file enables automatic initialization of GitHub-related hooks when a Claude session starts. This ensures that the necessary GitHub setup is performed without requiring manual intervention, improving the development workflow setup process.