### PR TITLE
Add go-test-coverage for stricter coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,21 +25,11 @@ jobs:
       - name: Run tests with coverage
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - name: Check test coverage
-        run: |
-          coverage=$(go tool cover -func=coverage.txt | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: ${coverage}%"
-          if (( $(echo "$coverage < 75" | bc -l) )); then
-            echo "Error: Test coverage is below 75% (current: ${coverage}%)"
-            exit 1
-          fi
+      - name: Install go-test-coverage
+        run: go install github.com/vladopajic/go-test-coverage/v2@latest
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.txt
-          flags: unittests
-          fail_ci_if_error: false
+      - name: Check test coverage
+        run: go-test-coverage --config .testcoverage.yml
 
   lint:
     name: Lint

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,14 @@
+# go-test-coverage configuration
+# https://github.com/vladopajic/go-test-coverage
+
+profile: coverage.txt
+
+threshold:
+  file: 75
+  package: 75
+  total: 75
+
+# Exclude test utilities from coverage requirements
+exclude:
+  paths:
+    - internal/testutil/.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,9 @@ golangci-lint run
 # Run tests with coverage
 go test -race -cover ./...
 
+# Check coverage (per-file, per-package, total >= 75%)
+make coverage
+
 # Security check
 govulncheck ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: test coverage lint build
+
+# Run tests with coverage
+test:
+	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+# Check coverage thresholds (per-file, per-package, total)
+coverage: test
+	go-test-coverage --config .testcoverage.yml
+
+# Run linter
+lint:
+	golangci-lint run
+
+# Build binary
+build:
+	go build -o bunny-api-proxy ./cmd/bunny-api-proxy


### PR DESCRIPTION
## Summary
Implements GitHub issue #32 - replaces bash-based coverage check with `go-test-coverage` tool for stricter per-file, per-package, and total coverage enforcement.

## Changes
- Create `.testcoverage.yml` with 75% thresholds for file/package/total coverage
- Create `Makefile` with test, coverage, lint, and build targets
- Update `.github/workflows/ci.yml` to use go-test-coverage instead of bash check
- Remove Codecov upload step (no longer needed)
- Update `CLAUDE.md` to document `make coverage` command

## Test Plan
- [x] `make test` passes locally with coverage.txt generation
- [ ] `make coverage` will pass on CI (go-test-coverage installed via GitHub Actions)
- [ ] Per-file threshold enforced (75%)
- [ ] Per-package threshold enforced (75%)
- [ ] Total threshold enforced (75%)
- [ ] Test utilities excluded from coverage requirements