### PR TITLE
Proxy: Implement core types and helper functions

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,0 +1,81 @@
+// Package proxy implements the API proxy for bunny.net requests.
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/sipico/bunny-api-proxy/internal/bunny"
+)
+
+// BunnyClient defines the bunny.net API operations needed by the proxy.
+// This interface enables testing with mock implementations.
+type BunnyClient interface {
+	// ListZones retrieves all DNS zones with optional filtering.
+	ListZones(ctx context.Context, opts *bunny.ListZonesOptions) (*bunny.ListZonesResponse, error)
+
+	// GetZone retrieves a single zone by ID, including all records.
+	GetZone(ctx context.Context, id int64) (*bunny.Zone, error)
+
+	// AddRecord creates a new DNS record in the specified zone.
+	AddRecord(ctx context.Context, zoneID int64, req *bunny.AddRecordRequest) (*bunny.Record, error)
+
+	// DeleteRecord removes a DNS record from the specified zone.
+	DeleteRecord(ctx context.Context, zoneID, recordID int64) error
+}
+
+// Handler handles proxy requests to bunny.net API.
+type Handler struct {
+	client BunnyClient
+	logger *slog.Logger
+}
+
+// NewHandler creates a new proxy handler.
+// If logger is nil, slog.Default() will be used.
+func NewHandler(client BunnyClient, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		client: client,
+		logger: logger,
+	}
+}
+
+// writeJSON writes a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		// Log encoding errors but don't fail the response
+		slog.Default().Error("failed to encode JSON response", "error", err)
+	}
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(map[string]string{"error": message})
+	if err != nil {
+		// Encoding errors on error responses are not critical
+		_ = err
+	}
+}
+
+// handleBunnyError maps bunny.net client errors to appropriate HTTP responses.
+func handleBunnyError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, bunny.ErrNotFound):
+		writeError(w, http.StatusNotFound, "resource not found")
+	case errors.Is(err, bunny.ErrUnauthorized):
+		// Master key issue - proxy's bunny.net credentials are invalid
+		writeError(w, http.StatusBadGateway, "upstream authentication failed")
+	default:
+		// Generic errors (network, parsing, etc.)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+	}
+}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,0 +1,221 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sipico/bunny-api-proxy/internal/bunny"
+)
+
+// mockBunnyClient implements BunnyClient for testing
+type mockBunnyClient struct{}
+
+func (m *mockBunnyClient) ListZones(ctx context.Context, opts *bunny.ListZonesOptions) (*bunny.ListZonesResponse, error) {
+	return nil, nil
+}
+
+func (m *mockBunnyClient) GetZone(ctx context.Context, id int64) (*bunny.Zone, error) {
+	return nil, nil
+}
+
+func (m *mockBunnyClient) AddRecord(ctx context.Context, zoneID int64, req *bunny.AddRecordRequest) (*bunny.Record, error) {
+	return nil, nil
+}
+
+func (m *mockBunnyClient) DeleteRecord(ctx context.Context, zoneID, recordID int64) error {
+	return nil
+}
+
+// TestNewHandler_WithLogger tests handler creation with non-nil logger
+func TestNewHandler_WithLogger(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+	client := &mockBunnyClient{}
+
+	handler := NewHandler(client, logger)
+
+	if handler == nil {
+		t.Fatalf("expected non-nil handler, got nil")
+	}
+	if handler.logger != logger {
+		t.Errorf("expected handler.logger to be the provided logger")
+	}
+	if handler.client != client {
+		t.Errorf("expected handler.client to be the provided client")
+	}
+}
+
+// TestNewHandler_NilLogger tests handler creation with nil logger
+func TestNewHandler_NilLogger(t *testing.T) {
+	client := &mockBunnyClient{}
+
+	handler := NewHandler(client, nil)
+
+	if handler == nil {
+		t.Fatalf("expected non-nil handler, got nil")
+	}
+	if handler.logger != slog.Default() {
+		t.Errorf("expected handler.logger to be slog.Default()")
+	}
+	if handler.client != client {
+		t.Errorf("expected handler.client to be the provided client")
+	}
+}
+
+// TestWriteJSON_Success tests successful JSON encoding
+func TestWriteJSON_Success(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	type testData struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	data := testData{Name: "test", Value: 42}
+	writeJSON(w, http.StatusOK, data)
+
+	// Check status code
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Check Content-Type header
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type 'application/json', got %q", ct)
+	}
+
+	// Check JSON body
+	var result testData
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Name != "test" || result.Value != 42 {
+		t.Errorf("expected data %+v, got %+v", data, result)
+	}
+}
+
+// TestWriteError_VariousStatuses tests error responses with different status codes
+func TestWriteError_VariousStatuses(t *testing.T) {
+	testCases := []struct {
+		status  int
+		message string
+	}{
+		{http.StatusBadRequest, "bad request"},
+		{http.StatusForbidden, "forbidden"},
+		{http.StatusNotFound, "not found"},
+		{http.StatusInternalServerError, "internal error"},
+		{http.StatusBadGateway, "bad gateway"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("status_%d", tc.status), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeError(w, tc.status, tc.message)
+
+			// Check status code
+			if w.Code != tc.status {
+				t.Errorf("expected status %d, got %d", tc.status, w.Code)
+			}
+
+			// Check Content-Type header
+			if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("expected Content-Type 'application/json', got %q", ct)
+			}
+
+			// Check error format
+			var result map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+			if result["error"] != tc.message {
+				t.Errorf("expected error message %q, got %q", tc.message, result["error"])
+			}
+		})
+	}
+}
+
+// TestHandleBunnyError_NotFound tests ErrNotFound error mapping
+func TestHandleBunnyError_NotFound(t *testing.T) {
+	w := httptest.NewRecorder()
+	handleBunnyError(w, bunny.ErrNotFound)
+
+	// Check status code
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+
+	// Check error message
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "resource not found" {
+		t.Errorf("expected error message 'resource not found', got %q", result["error"])
+	}
+}
+
+// TestHandleBunnyError_Unauthorized tests ErrUnauthorized error mapping
+func TestHandleBunnyError_Unauthorized(t *testing.T) {
+	w := httptest.NewRecorder()
+	handleBunnyError(w, bunny.ErrUnauthorized)
+
+	// Check status code
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d, got %d", http.StatusBadGateway, w.Code)
+	}
+
+	// Check error message
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "upstream authentication failed" {
+		t.Errorf("expected error message containing 'upstream', got %q", result["error"])
+	}
+}
+
+// TestHandleBunnyError_GenericError tests generic error mapping
+func TestHandleBunnyError_GenericError(t *testing.T) {
+	w := httptest.NewRecorder()
+	err := fmt.Errorf("network timeout")
+	handleBunnyError(w, err)
+
+	// Check status code
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	// Check error message
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "internal server error" {
+		t.Errorf("expected error message 'internal server error', got %q", result["error"])
+	}
+}
+
+// TestHandleBunnyError_WrappedErrors tests error mapping with wrapped errors
+func TestHandleBunnyError_WrappedErrors(t *testing.T) {
+	w := httptest.NewRecorder()
+	err := fmt.Errorf("failed: %w", bunny.ErrNotFound)
+	handleBunnyError(w, err)
+
+	// Check status code - should still map to 404 because errors.Is unwraps
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+
+	// Check error message
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "resource not found" {
+		t.Errorf("expected error message 'resource not found', got %q", result["error"])
+	}
+}


### PR DESCRIPTION
Closes #71

Implements:
- BunnyClient interface defining the proxy's required methods (ListZones, GetZone, AddRecord, DeleteRecord)
- Handler struct with client dependency and logger
- NewHandler constructor with nil-safe logger defaulting to slog.Default()
- writeJSON helper function for JSON responses
- writeError helper function for error responses
- handleBunnyError function for mapping bunny.net errors to HTTP status codes

Test coverage:
- TestNewHandler_WithLogger: Handler created with provided logger
- TestNewHandler_NilLogger: Handler uses slog.Default() when nil logger provided
- TestWriteJSON_Success: Successful JSON response encoding
- TestWriteError_VariousStatuses: Error responses with various HTTP status codes
- TestHandleBunnyError_NotFound: ErrNotFound maps to 404
- TestHandleBunnyError_Unauthorized: ErrUnauthorized maps to 502
- TestHandleBunnyError_GenericError: Generic errors map to 500
- TestHandleBunnyError_WrappedErrors: Wrapped errors are properly unwrapped and mapped

Package coverage: 87.5% (exceeds 75% minimum)

Part of Issue A (#70) - Foundation for proxy package that Issues B and C depend on