### PR TITLE
docs: Add response filtering to future enhancements

### DIFF
--- a/FUTURE_ENHANCEMENTS.md
+++ b/FUTURE_ENHANCEMENTS.md
@@ -23,6 +23,15 @@ This document tracks features and improvements deferred from MVP to keep scope m
 
 ## Permission Model
 
+### Response Filtering (Data Privacy)
+
+- [ ] **Filter ListZones response** - Return only zones the scoped key has permission for
+  - Currently: Key for Zone A can see Zones B, C in ListZones response
+  - Desired: ListZones returns only zones with matching permissions
+  - Implementation: Add `FilterResponse()` function in proxy handlers
+  - Empty result = empty array (valid response, not error)
+  - Note: Request validation prevents privilege escalation; this adds data privacy
+
 ### Pattern Matching
 
 - [ ] **Zone name patterns** - e.g., "all .nl domains", "zones containing 'prod'"


### PR DESCRIPTION
Track data privacy feature for post-MVP implementation.

## Change
Added to FUTURE_ENHANCEMENTS.md under Permission Model:
- Response filtering for ListZones
- Return only zones the scoped key has permission for

## Rationale
- Access control already prevents privilege escalation
- This adds data privacy (can't see unauthorized zone names)
- Low priority: MVP use case (ACME DNS-01) doesn't require it
- Non-breaking: can be added later without API changes