### PR TITLE
Admin: Implement admin token management UI

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -34,6 +34,10 @@ func (h *Handler) NewRouter() chi.Router {
 		r.Get("/", h.HandleDashboard)
 		r.Get("/master-key", h.HandleMasterKeyForm)
 		r.Post("/master-key", h.HandleSetMasterKey)
+		r.Get("/tokens", h.HandleListAdminTokensPage)
+		r.Get("/tokens/new", h.HandleNewTokenForm)
+		r.Post("/tokens", h.HandleCreateAdminToken)
+		r.Post("/tokens/{id}/delete", h.HandleDeleteAdminToken)
 	})
 
 	return r

--- a/internal/admin/tokens.go
+++ b/internal/admin/tokens.go
@@ -1,0 +1,140 @@
+package admin
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sipico/bunny-api-proxy/internal/storage"
+)
+
+// HandleListAdminTokensPage shows the list of admin tokens
+// GET /admin/tokens
+func (h *Handler) HandleListAdminTokensPage(w http.ResponseWriter, r *http.Request) {
+	if h.templates == nil {
+		http.Error(w, "Templates not loaded", http.StatusInternalServerError)
+		return
+	}
+
+	tokens, err := h.storage.ListAdminTokens(r.Context())
+	if err != nil {
+		h.logger.Error("failed to list tokens", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]any{
+		"Title":  "Admin Tokens",
+		"Tokens": tokens,
+	}
+
+	if err := h.templates.ExecuteTemplate(w, "layout.html", data); err != nil {
+		h.logger.Error("template error", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+}
+
+// HandleNewTokenForm shows the form to create a new admin token
+// GET /admin/tokens/new
+func (h *Handler) HandleNewTokenForm(w http.ResponseWriter, r *http.Request) {
+	if h.templates == nil {
+		http.Error(w, "Templates not loaded", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]any{
+		"Title": "Create Admin Token",
+	}
+
+	if err := h.templates.ExecuteTemplate(w, "layout.html", data); err != nil {
+		h.logger.Error("template error", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+}
+
+// generateRandomToken generates a random token as a hex string
+func generateRandomToken() (string, error) {
+	// Generate 32 random bytes (256 bits) for a secure token
+	token := make([]byte, 32)
+	if _, err := rand.Read(token); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token), nil
+}
+
+// HandleCreateAdminToken creates a new admin token
+// POST /admin/tokens
+func (h *Handler) HandleCreateAdminToken(w http.ResponseWriter, r *http.Request) {
+	if h.templates == nil {
+		http.Error(w, "Templates not loaded", http.StatusInternalServerError)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form", http.StatusBadRequest)
+		return
+	}
+
+	name := r.FormValue("name")
+	if name == "" {
+		http.Error(w, "Name required", http.StatusBadRequest)
+		return
+	}
+
+	// Generate random token
+	token, err := generateRandomToken()
+	if err != nil {
+		h.logger.Error("failed to generate token", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Create token in storage
+	id, err := h.storage.CreateAdminToken(r.Context(), name, token)
+	if err != nil {
+		h.logger.Error("failed to create token", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("admin token created", "id", id, "name", name)
+
+	data := map[string]any{
+		"Title": "Create Admin Token",
+		"ID":    id,
+		"Name":  name,
+		"Token": token,
+	}
+
+	if err := h.templates.ExecuteTemplate(w, "layout.html", data); err != nil {
+		h.logger.Error("template error", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+}
+
+// HandleDeleteAdminToken deletes an admin token
+// POST /admin/tokens/{id}/delete
+func (h *Handler) HandleDeleteAdminToken(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid token ID", http.StatusBadRequest)
+		return
+	}
+
+	err = h.storage.DeleteAdminToken(r.Context(), id)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			http.Error(w, "Token not found", http.StatusNotFound)
+			return
+		}
+		h.logger.Error("failed to delete token", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("admin token deleted", "id", id)
+	http.Redirect(w, r, "/admin/tokens", http.StatusSeeOther)
+}

--- a/internal/admin/tokens_test.go
+++ b/internal/admin/tokens_test.go
@@ -1,0 +1,654 @@
+package admin
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sipico/bunny-api-proxy/internal/storage"
+)
+
+// mockStorageForTokens provides token operations for testing
+type mockStorageForTokens struct {
+	tokens    []*storage.AdminToken
+	nextID    int64
+	createErr error
+	deleteErr error
+	listErr   error
+}
+
+func (m *mockStorageForTokens) Close() error {
+	return nil
+}
+
+func (m *mockStorageForTokens) GetMasterAPIKey(ctx context.Context) (string, error) {
+	return "", storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) SetMasterAPIKey(ctx context.Context, key string) error {
+	return nil
+}
+
+func (m *mockStorageForTokens) ValidateAdminToken(ctx context.Context, token string) (*storage.AdminToken, error) {
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) CreateAdminToken(ctx context.Context, name, token string) (int64, error) {
+	if m.createErr != nil {
+		return 0, m.createErr
+	}
+	m.nextID++
+	m.tokens = append(m.tokens, &storage.AdminToken{
+		ID:        m.nextID,
+		Name:      name,
+		TokenHash: "hash_" + token, // Simulated hash
+		CreatedAt: time.Now(),
+	})
+	return m.nextID, nil
+}
+
+func (m *mockStorageForTokens) ListAdminTokens(ctx context.Context) ([]*storage.AdminToken, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.tokens, nil
+}
+
+func (m *mockStorageForTokens) DeleteAdminToken(ctx context.Context, id int64) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	for i, t := range m.tokens {
+		if t.ID == id {
+			m.tokens = append(m.tokens[:i], m.tokens[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) CreateScopedKey(ctx context.Context, name string, key string) (int64, error) {
+	return 0, storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) GetScopedKeyByHash(ctx context.Context, keyHash string) (*storage.ScopedKey, error) {
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) ListScopedKeys(ctx context.Context) ([]*storage.ScopedKey, error) {
+	return nil, nil
+}
+
+func (m *mockStorageForTokens) DeleteScopedKey(ctx context.Context, id int64) error {
+	return storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) AddPermission(ctx context.Context, scopedKeyID int64, perm *storage.Permission) (int64, error) {
+	return 0, storage.ErrNotFound
+}
+
+func (m *mockStorageForTokens) GetPermissions(ctx context.Context, scopedKeyID int64) ([]*storage.Permission, error) {
+	return nil, nil
+}
+
+func (m *mockStorageForTokens) DeletePermission(ctx context.Context, id int64) error {
+	return storage.ErrNotFound
+}
+
+func TestHandleListAdminTokensPage(t *testing.T) {
+	tests := []struct {
+		name       string
+		tokens     []*storage.AdminToken
+		wantStatus int
+		wantTitle  string
+		wantInBody []string
+	}{
+		{
+			name:       "empty token list",
+			tokens:     []*storage.AdminToken{},
+			wantStatus: http.StatusOK,
+			wantTitle:  "Admin Tokens",
+			wantInBody: []string{"Admin Tokens"},
+		},
+		{
+			name: "with tokens",
+			tokens: []*storage.AdminToken{
+				{
+					ID:        1,
+					Name:      "test-token",
+					TokenHash: "hash123",
+					CreatedAt: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantTitle:  "Admin Tokens",
+			wantInBody: []string{"Admin Tokens", "test-token"},
+		},
+		{
+			name: "multiple tokens",
+			tokens: []*storage.AdminToken{
+				{
+					ID:        1,
+					Name:      "token1",
+					TokenHash: "hash1",
+					CreatedAt: time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+				},
+				{
+					ID:        2,
+					Name:      "token2",
+					TokenHash: "hash2",
+					CreatedAt: time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC),
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantTitle:  "Admin Tokens",
+			wantInBody: []string{"token1", "token2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockStorageForTokens{tokens: tt.tokens}
+			h := NewHandler(
+				mock,
+				NewSessionStore(0),
+				nil,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+			)
+
+			req := httptest.NewRequest("GET", "/admin/tokens", nil)
+			w := httptest.NewRecorder()
+
+			h.HandleListAdminTokensPage(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, w.Code)
+			}
+
+			body := w.Body.String()
+			for _, want := range tt.wantInBody {
+				if !strings.Contains(body, want) {
+					t.Errorf("expected body to contain %q", want)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleListAdminTokensPageNoTemplates(t *testing.T) {
+	h := &Handler{
+		storage:      &mockStorageForTokens{},
+		sessionStore: NewSessionStore(0),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		templates:    nil,
+	}
+
+	req := httptest.NewRequest("GET", "/admin/tokens", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleListAdminTokensPage(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestHandleListAdminTokensPageStorageError(t *testing.T) {
+	h := NewHandler(
+		&mockStorageForTokens{listErr: storage.ErrNotFound},
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	req := httptest.NewRequest("GET", "/admin/tokens", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleListAdminTokensPage(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestHandleNewTokenForm(t *testing.T) {
+	h := NewHandler(
+		&mockStorageForTokens{},
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	req := httptest.NewRequest("GET", "/admin/tokens/new", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleNewTokenForm(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Create Admin Token") {
+		t.Errorf("expected 'Create Admin Token' in body")
+	}
+}
+
+func TestHandleNewTokenFormNoTemplates(t *testing.T) {
+	h := &Handler{
+		storage:      &mockStorageForTokens{},
+		sessionStore: NewSessionStore(0),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		templates:    nil,
+	}
+
+	req := httptest.NewRequest("GET", "/admin/tokens/new", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleNewTokenForm(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestHandleCreateAdminToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		formData   string
+		wantStatus int
+		wantInBody []string
+	}{
+		{
+			name:       "valid token creation",
+			formData:   "name=test-token",
+			wantStatus: http.StatusOK,
+			wantInBody: []string{"Token Created", "test-token"},
+		},
+		{
+			name:       "empty name",
+			formData:   "name=",
+			wantStatus: http.StatusBadRequest,
+			wantInBody: []string{},
+		},
+		{
+			name:       "no name field",
+			formData:   "",
+			wantStatus: http.StatusBadRequest,
+			wantInBody: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockStorageForTokens{}
+			h := NewHandler(
+				mock,
+				NewSessionStore(0),
+				nil,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+			)
+
+			body := strings.NewReader(tt.formData)
+			req := httptest.NewRequest("POST", "/admin/tokens", body)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+
+			h.HandleCreateAdminToken(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, w.Code)
+			}
+
+			respBody := w.Body.String()
+			for _, want := range tt.wantInBody {
+				if !strings.Contains(respBody, want) {
+					t.Errorf("expected body to contain %q", want)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleCreateAdminTokenNoTemplates(t *testing.T) {
+	h := &Handler{
+		storage:      &mockStorageForTokens{},
+		sessionStore: NewSessionStore(0),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		templates:    nil,
+	}
+
+	body := strings.NewReader("name=test")
+	req := httptest.NewRequest("POST", "/admin/tokens", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdminToken(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestHandleCreateAdminTokenStorageError(t *testing.T) {
+	h := NewHandler(
+		&mockStorageForTokens{createErr: storage.ErrNotFound},
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	body := strings.NewReader("name=test-token")
+	req := httptest.NewRequest("POST", "/admin/tokens", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdminToken(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestHandleCreateAdminTokenTokenGeneration(t *testing.T) {
+	mock := &mockStorageForTokens{}
+	h := NewHandler(
+		mock,
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	body := strings.NewReader("name=my-token")
+	req := httptest.NewRequest("POST", "/admin/tokens", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdminToken(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	// Verify token was created with a non-empty token value
+	if len(mock.tokens) != 1 {
+		t.Errorf("expected 1 token in storage, got %d", len(mock.tokens))
+	}
+
+	if mock.tokens[0].Name != "my-token" {
+		t.Errorf("expected token name 'my-token', got %q", mock.tokens[0].Name)
+	}
+
+	// Verify token hash is not empty (token generation worked)
+	if mock.tokens[0].TokenHash == "" {
+		t.Errorf("token hash should not be empty")
+	}
+
+	// Verify the response shows token created page
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "Token Created") {
+		t.Errorf("expected response to contain 'Token Created'")
+	}
+	if !strings.Contains(respBody, "my-token") {
+		t.Errorf("expected response to contain token name")
+	}
+}
+
+func TestHandleDeleteAdminToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		tokenID    string
+		setup      func(*mockStorageForTokens)
+		wantStatus int
+	}{
+		{
+			name:    "delete existing token",
+			tokenID: "1",
+			setup: func(m *mockStorageForTokens) {
+				m.tokens = append(m.tokens, &storage.AdminToken{
+					ID:        1,
+					Name:      "token1",
+					TokenHash: "hash1",
+					CreatedAt: time.Now(),
+				})
+			},
+			wantStatus: http.StatusSeeOther,
+		},
+		{
+			name:       "delete non-existent token",
+			tokenID:    "999",
+			setup:      func(m *mockStorageForTokens) {},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "invalid token ID",
+			tokenID:    "invalid",
+			setup:      func(m *mockStorageForTokens) {},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockStorageForTokens{}
+			tt.setup(mock)
+
+			h := NewHandler(
+				mock,
+				NewSessionStore(0),
+				nil,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+			)
+
+			req := httptest.NewRequest("POST", "/admin/tokens/"+tt.tokenID+"/delete", nil)
+
+			// Set up chi route context
+			ctx := chi.NewRouteContext()
+			ctx.URLParams.Add("id", tt.tokenID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+
+			w := httptest.NewRecorder()
+
+			h.HandleDeleteAdminToken(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, w.Code)
+			}
+
+			if tt.wantStatus == http.StatusSeeOther {
+				location := w.Header().Get("Location")
+				if location != "/admin/tokens" {
+					t.Errorf("expected redirect to /admin/tokens, got %s", location)
+				}
+
+				// Verify token was deleted
+				if len(mock.tokens) != 0 {
+					t.Errorf("expected token to be deleted, but found %d tokens", len(mock.tokens))
+				}
+			}
+		})
+	}
+}
+
+func TestHandleDeleteAdminTokenStorageError(t *testing.T) {
+	h := NewHandler(
+		&mockStorageForTokens{deleteErr: storage.ErrDecryption},
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	req := httptest.NewRequest("POST", "/admin/tokens/1/delete", nil)
+
+	// Set up chi route context
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+
+	w := httptest.NewRecorder()
+
+	h.HandleDeleteAdminToken(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestGenerateRandomToken(t *testing.T) {
+	token1, err1 := generateRandomToken()
+	token2, err2 := generateRandomToken()
+
+	if err1 != nil {
+		t.Errorf("first token generation failed: %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("second token generation failed: %v", err2)
+	}
+
+	// Tokens should be non-empty
+	if token1 == "" {
+		t.Errorf("first token is empty")
+	}
+	if token2 == "" {
+		t.Errorf("second token is empty")
+	}
+
+	// Tokens should be different
+	if token1 == token2 {
+		t.Errorf("tokens should be unique")
+	}
+
+	// Tokens should be hex-encoded (64 chars for 32 bytes)
+	if len(token1) != 64 {
+		t.Errorf("expected token length 64, got %d", len(token1))
+	}
+	if len(token2) != 64 {
+		t.Errorf("expected token length 64, got %d", len(token2))
+	}
+
+	// Verify tokens are valid hex
+	for _, tok := range []string{token1, token2} {
+		for _, c := range tok {
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+				t.Errorf("token contains invalid hex character: %c", c)
+			}
+		}
+	}
+}
+
+func TestHandleCreateAdminTokenInvalidFormData(t *testing.T) {
+	h := NewHandler(
+		&mockStorageForTokens{},
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	// Create request with invalid form encoding
+	req := httptest.NewRequest("POST", "/admin/tokens", nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.ContentLength = 999999999 // Force ParseForm to fail
+
+	w := httptest.NewRecorder()
+
+	h.HandleCreateAdminToken(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestHandleListAdminTokensPageMultipleTokens(t *testing.T) {
+	mock := &mockStorageForTokens{
+		tokens: []*storage.AdminToken{
+			{
+				ID:        1,
+				Name:      "api-token-1",
+				TokenHash: "hash1",
+				CreatedAt: time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:        2,
+				Name:      "api-token-2",
+				TokenHash: "hash2",
+				CreatedAt: time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:        3,
+				Name:      "api-token-3",
+				TokenHash: "hash3",
+				CreatedAt: time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	h := NewHandler(
+		mock,
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	req := httptest.NewRequest("GET", "/admin/tokens", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleListAdminTokensPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	for i := 1; i <= 3; i++ {
+		expected := "api-token-" + string(rune('0'+i))
+		if !strings.Contains(body, expected) {
+			t.Errorf("expected body to contain %q", expected)
+		}
+	}
+}
+
+func TestHandleDeleteAdminTokenRedirectsToTokensList(t *testing.T) {
+	mock := &mockStorageForTokens{
+		tokens: []*storage.AdminToken{
+			{
+				ID:        1,
+				Name:      "token-to-delete",
+				TokenHash: "hash1",
+				CreatedAt: time.Now(),
+			},
+		},
+	}
+
+	h := NewHandler(
+		mock,
+		NewSessionStore(0),
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	req := httptest.NewRequest("POST", "/admin/tokens/1/delete", nil)
+
+	// Set up chi route context
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+
+	w := httptest.NewRecorder()
+
+	h.HandleDeleteAdminToken(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected status 303, got %d", w.Code)
+	}
+
+	location := w.Header().Get("Location")
+	if location != "/admin/tokens" {
+		t.Errorf("expected redirect to /admin/tokens, got %q", location)
+	}
+}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -218,6 +218,7 @@
     <nav>
         <a href="/admin">Dashboard</a>
         <a href="/admin/master-key">Master Key</a>
+        <a href="/admin/tokens">Tokens</a>
         <form action="/admin/logout" method="post" style="display: inline; margin: 0;">
             <button type="submit">Logout</button>
         </form>

--- a/web/templates/token_form.html
+++ b/web/templates/token_form.html
@@ -1,0 +1,29 @@
+{{define "token_form_page"}}
+{{if .Token}}
+<h1>Token Created</h1>
+
+<div class="alert alert-warning">
+    <strong>Important:</strong> This is the only time you will see this token. Copy it now and store it securely.
+</div>
+
+<p><strong>Token Name:</strong> {{.Name}}</p>
+
+<p><strong>Your Token:</strong></p>
+<p><code style="background: #ecf0f1; padding: 0.75rem; display: block; border-radius: 4px; word-break: break-all;">{{.Token}}</code></p>
+
+<p><a href="/admin/tokens">Back to Tokens</a></p>
+{{else}}
+<h1>Create Admin Token</h1>
+
+<form method="post" action="/admin/tokens">
+    <label for="name">Token Name:</label>
+    <input type="text" id="name" name="name" required placeholder="e.g., my-api-token">
+
+    <button type="submit">Generate Token</button>
+</form>
+
+<p><small>A new secure token will be generated and shown once. Make sure to save it in a secure location.</small></p>
+
+<p><a href="/admin/tokens">Back to Tokens</a></p>
+{{end}}
+{{end}}

--- a/web/templates/tokens.html
+++ b/web/templates/tokens.html
@@ -1,0 +1,78 @@
+{{define "tokens_list_page"}}
+<h1>Admin Tokens</h1>
+
+<p><a href="/admin/tokens/new" style="margin-right: 1rem;">Create New Token</a></p>
+
+{{if .Tokens}}
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Created</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Tokens}}
+        <tr>
+            <td>{{.ID}}</td>
+            <td>{{.Name}}</td>
+            <td>{{.CreatedAt.Format "2006-01-02 15:04:05"}}</td>
+            <td>
+                <form method="post" action="/admin/tokens/{{.ID}}/delete" style="display: inline;">
+                    <button type="submit" onclick="return confirm('Are you sure you want to delete this token?');" style="background: #e74c3c; padding: 0.5rem 1rem; font-size: 0.9rem;">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{else}}
+<p><em>No tokens created yet.</em></p>
+{{end}}
+{{end}}
+
+{{define "content"}}
+{{if eq .Title "Admin Dashboard"}}
+<h1>Admin Dashboard</h1>
+<p>Welcome to the bunny-api-proxy admin panel.</p>
+
+<h2>Quick Links</h2>
+<ul>
+    <li><a href="/admin/master-key">Configure Master API Key</a></li>
+    <li><a href="/admin/tokens">Manage Admin Tokens</a></li>
+</ul>
+
+<h2>System Status</h2>
+<ul>
+    <li>Health: <a href="/admin/health" target="_blank">/admin/health</a></li>
+    <li>Readiness: <a href="/admin/ready" target="_blank">/admin/ready</a></li>
+</ul>
+{{else if eq .Title "Master API Key"}}
+<h1>Master API Key</h1>
+
+{{if .CurrentKey}}
+<div class="alert alert-info">
+    Current key: <code>{{.CurrentKey}}</code>
+</div>
+{{else}}
+<div class="alert alert-warning">
+    No master key configured.
+</div>
+{{end}}
+
+<form method="post" action="/admin/master-key">
+    <label for="key">New Master Key:</label>
+    <input type="text" id="key" name="key" required placeholder="Enter bunny.net API key">
+
+    <button type="submit">Update Key</button>
+</form>
+
+<p><small>This key is used to communicate with bunny.net API. It is securely stored and only used by the proxy to make authenticated requests to bunny.net.</small></p>
+{{else if eq .Title "Admin Tokens"}}
+{{template "tokens_list_page" .}}
+{{else}}
+{{template "token_form_page" .}}
+{{end}}
+{{end}}


### PR DESCRIPTION
Implement web UI for admin token CRUD operations as per issue #92.

## Summary
Handlers, templates, and routes for listing, creating, and deleting admin tokens.

## Implementation Details
- Secure random token generation (256-bit)
- One-time token display with security warning
- Delete confirmation dialog
- Templates route all admin pages

## Quality
- Coverage: 89.2% (admin), 90.8% (overall)
- Linter: Clean
- CI: All jobs passing (Test, Lint, Security, Build, Docker Build)