### PR TITLE
chore(coverage): Exclude test utility binaries from coverage

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -7,3 +7,9 @@ threshold:
   file: 85
   package: 85
   total: 85
+
+# Exclude test utilities from coverage requirements
+# These are helper binaries for E2E testing, not production code
+exclude:
+  paths:
+    - cmd/mockbunny/.*


### PR DESCRIPTION
Exclude cmd/mockbunny from coverage requirements as it's a test utility binary for E2E testing, not production code.