### PR TITLE
fix(docker): Include web templates and remove obsolete version attribute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/bunny-api-proxy .
 
-# TODO: Copy web assets when Admin UI is implemented
-# COPY --from=builder /app/web ./web
+# Copy web assets (templates, static files)
+COPY --from=builder /app/web ./web
 
 # Create non-root user
 RUN addgroup -g 1000 bunny && \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mockbunny:
     build:


### PR DESCRIPTION
## Summary

- Include `/app/web` directory in the final Docker image to serve HTML templates for admin UI
- Remove obsolete `version` attribute from docker-compose.test.yml

## Problem

The proxy container was failing to load templates:
```
html/template: pattern matches no files: `/home/bunny/bunny-api-proxy/web/templates/*.html`
```

This was because the Dockerfile had a TODO to copy web assets that was never uncommented.

## Changes

1. **Dockerfile**: Uncommented `COPY --from=builder /app/web ./web`
2. **docker-compose.test.yml**: Removed `version: '3.8'` (obsolete in modern Docker Compose)

## Test plan

- [ ] Docker build succeeds
- [ ] Admin UI loads correctly with templates