### PR TITLE
feat(auth): migrate from Bearer to AccessKey header

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,7 +193,7 @@ docker run -d \
 | Access Type | Auth Method | Purpose |
 |-------------|-------------|---------|
 | Web UI | Password → session cookie | Human admin interaction |
-| Admin API | Bearer token | Scripts, automation |
+| Admin API | AccessKey token | Scripts, automation |
 
 - Admin password: Only entered in web login form
 - Admin API token: Generated via Web UI, stored hashed in DB

--- a/docs/API.md
+++ b/docs/API.md
@@ -453,10 +453,10 @@ Admin endpoints for managing the proxy itself (master API key, scoped keys, admi
 
 Admin API endpoints support two authentication methods:
 
-#### 1. Bearer Token (Recommended)
-Use a Bearer token created via the admin UI or API:
+#### 1. AccessKey Token (Recommended)
+Use an AccessKey token created via the admin UI or API:
 ```
-Authorization: Bearer <admin-token>
+AccessKey: <admin-token>
 ```
 
 #### 2. Basic Auth (Bootstrap Only)
@@ -576,7 +576,7 @@ Change the runtime log level.
 **Example Request:**
 ```bash
 curl -X POST http://localhost:8080/admin/api/loglevel \
-  -H "Authorization: Bearer <admin-token>" \
+  -H "AccessKey: <admin-token>" \
   -H "Content-Type: application/json" \
   -d '{"level": "debug"}'
 ```
@@ -602,7 +602,7 @@ List all admin tokens (names and IDs only - tokens are never returned after crea
 **Example Request:**
 ```bash
 curl -X GET http://localhost:8080/admin/api/tokens \
-  -H "Authorization: Bearer <admin-token>"
+  -H "AccessKey: <admin-token>"
 ```
 
 **Example Response:**
@@ -643,7 +643,7 @@ Create a new admin token.
 **Example Request:**
 ```bash
 curl -X POST http://localhost:8080/admin/api/tokens \
-  -H "Authorization: Bearer <admin-token>" \
+  -H "AccessKey: <admin-token>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-new-token",
@@ -675,7 +675,7 @@ Delete an admin token by ID.
 **Example Request:**
 ```bash
 curl -X DELETE http://localhost:8080/admin/api/tokens/1 \
-  -H "Authorization: Bearer <admin-token>"
+  -H "AccessKey: <admin-token>"
 ```
 
 **Error Responses:**
@@ -700,7 +700,7 @@ Set the master bunny.net API key (can only be set once).
 **Example Request:**
 ```bash
 curl -X PUT http://localhost:8080/admin/api/master-key \
-  -H "Authorization: Bearer <admin-token>" \
+  -H "AccessKey: <admin-token>" \
   -H "Content-Type: application/json" \
   -d '{"api_key": "12345abcde-bunny-api-key"}'
 ```
@@ -747,7 +747,7 @@ Create a new scoped API key with permissions in one operation.
 **Example Request:**
 ```bash
 curl -X POST http://localhost:8080/admin/api/keys \
-  -H "Authorization: Bearer <admin-token>" \
+  -H "AccessKey: <admin-token>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "acme-client",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -331,7 +331,7 @@ For automated key management via scripts:
 4. Use for automated administration:
 
 ```bash
-curl -H "Authorization: Bearer admin-token-here" \
+curl -H "AccessKey: admin-token-here" \
   http://localhost:8080/admin/api/keys
 ```
 
@@ -1004,7 +1004,7 @@ groups:
 
 ```bash
 curl -X POST http://localhost:8080/admin/api/loglevel \
-  -H "Authorization: Bearer admin-token" \
+  -H "AccessKey: admin-token" \
   -H "Content-Type: application/json" \
   -d '{"level":"debug"}'
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -11,7 +11,7 @@ The Bunny API Proxy implements a **two-tier authentication architecture** design
 | Tier | Users | Purpose | Auth Method |
 |------|-------|---------|-------------|
 | **Admin** | Humans, automation | Manage proxy configuration | Password + session cookies or bearer tokens |
-| **Scoped Proxy Keys** | API clients (ACME, etc.) | Limited access to bunny.net API | Bearer tokens with explicit permissions |
+| **Scoped Proxy Keys** | API clients (ACME, etc.) | Limited access to bunny.net API | AccessKey tokens with explicit permissions |
 
 ### Principle of Least Privilege
 
@@ -74,11 +74,11 @@ Example permission model:
 
 ### 2.2 Admin API Authentication
 
-**Flow**: Bearer Token or Basic Auth → Validated → Request Processing
+**Flow**: AccessKey Token or Basic Auth → Validated → Request Processing
 
-#### Bearer Token Authentication
+#### AccessKey Token Authentication
 - **Endpoint**: Any `POST /admin/api/*` endpoint
-- **Header format**: `Authorization: Bearer <token>`
+- **Header format**: `AccessKey: <token>`
 - **Token validation**:
   1. Token is hashed with SHA-256
   2. Hash is compared against stored admin token hashes in database
@@ -105,12 +105,12 @@ Example permission model:
 
 ### 2.3 Proxy API (Scoped Keys)
 
-**Flow**: Bearer Token → Key Validation → Permission Check → Proxying
+**Flow**: AccessKey Token → Key Validation → Permission Check → Proxying
 
 #### Key Validation
-- **Header format**: `Authorization: Bearer <scoped-key>`
+- **Header format**: `AccessKey: <scoped-key>`
 - **Validation process**:
-  1. Extract key from `Authorization` header
+  1. Extract key from `AccessKey` header
   2. Load all scoped keys from database
   3. Compare provided key against each bcrypt hash
   4. Return KeyInfo (ID, name, permissions) if match found
@@ -563,7 +563,7 @@ The admin password is **never stored** in the database or files:
 **Threat**: API client makes request without API key or with invalid key
 
 **Mitigation**:
-- Middleware enforces Bearer token requirement
+- Middleware enforces AccessKey requirement
 - All requests validated before reaching handlers
 - Invalid keys logged with remote IP for detection
 

--- a/internal/admin/token_auth.go
+++ b/internal/admin/token_auth.go
@@ -15,15 +15,16 @@ type TokenInfo struct {
 	Name string
 }
 
-// TokenAuthMiddleware validates Bearer tokens or Basic Auth for admin API
+// TokenAuthMiddleware validates AccessKey tokens or Basic Auth for admin API
 // It accepts either:
-// - Bearer token: validated against stored admin tokens
+// - AccessKey token: validated against stored admin tokens
 // - Basic auth: username "admin" with the admin password (for bootstrapping)
 func (h *Handler) TokenAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			http.Error(w, "Missing Authorization header", http.StatusUnauthorized)
+		accessKey := r.Header.Get("AccessKey")
+		if authHeader == "" && accessKey == "" {
+			http.Error(w, "missing API key", http.StatusUnauthorized)
 			return
 		}
 
@@ -54,16 +55,10 @@ func (h *Handler) TokenAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Check "Bearer " prefix
-		const bearerPrefix = "Bearer "
-		if !strings.HasPrefix(authHeader, bearerPrefix) {
-			http.Error(w, "Invalid Authorization header format", http.StatusUnauthorized)
-			return
-		}
-
-		token := strings.TrimPrefix(authHeader, bearerPrefix)
+		// Check AccessKey header
+		token := strings.TrimSpace(accessKey)
 		if token == "" {
-			http.Error(w, "Missing token", http.StatusUnauthorized)
+			http.Error(w, "missing API key", http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/admin/token_auth_test.go
+++ b/internal/admin/token_auth_test.go
@@ -68,7 +68,7 @@ func (m *mockStorageWithToken) DeletePermission(ctx context.Context, id int64) e
 func TestTokenAuthMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string
-		authHeader     string
+		accessKey      string
 		validateResult *storage.AdminToken
 		validateError  error
 		adminPassword  string // Set ADMIN_PASSWORD env for basic auth tests
@@ -76,8 +76,8 @@ func TestTokenAuthMiddleware(t *testing.T) {
 		wantContext    bool // Should token info be in context?
 	}{
 		{
-			name:       "valid token",
-			authHeader: "Bearer valid-token-123",
+			name:      "valid token",
+			accessKey: "valid-token-123",
 			validateResult: &storage.AdminToken{
 				ID:   1,
 				Name: "test-token",
@@ -87,28 +87,23 @@ func TestTokenAuthMiddleware(t *testing.T) {
 		},
 		{
 			name:       "missing header",
-			authHeader: "",
-			wantStatus: http.StatusUnauthorized,
-		},
-		{
-			name:       "invalid format - unknown prefix",
-			authHeader: "Digest abc123",
+			accessKey:  "",
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:       "empty token",
-			authHeader: "Bearer ",
+			accessKey:  "",
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:          "invalid token - not in database",
-			authHeader:    "Bearer invalid-token",
+			accessKey:     "invalid-token",
 			validateError: storage.ErrNotFound,
 			wantStatus:    http.StatusUnauthorized,
 		},
 		{
 			name:          "database error",
-			authHeader:    "Bearer valid-token",
+			accessKey:     "valid-token",
 			validateError: errors.New("database error"),
 			wantStatus:    http.StatusInternalServerError,
 		},
@@ -157,8 +152,8 @@ func TestTokenAuthMiddleware(t *testing.T) {
 
 			// Create request
 			req := httptest.NewRequest("GET", "/api/test", nil)
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
+			if tt.accessKey != "" {
+				req.Header.Set("AccessKey", tt.accessKey)
 			}
 			w := httptest.NewRecorder()
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -16,8 +16,8 @@ const keyInfoContextKey contextKey = "keyInfo"
 func Middleware(v *Validator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Extract API key from Authorization header
-			apiKey := extractBearerToken(r)
+			// Extract API key from AccessKey header
+			apiKey := extractAccessKey(r)
 			if apiKey == "" {
 				writeJSONError(w, http.StatusUnauthorized, "missing API key")
 				return
@@ -64,17 +64,9 @@ func GetKeyInfo(ctx context.Context) *KeyInfo {
 	return nil
 }
 
-// extractBearerToken gets token from "Authorization: Bearer <token>" header
-func extractBearerToken(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return ""
-	}
-	parts := strings.SplitN(auth, " ", 2)
-	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-		return ""
-	}
-	return parts[1]
+// extractAccessKey gets API key from "AccessKey" header
+func extractAccessKey(r *http.Request) string {
+	return strings.TrimSpace(r.Header.Get("AccessKey"))
 }
 
 // writeJSONError writes a JSON error response

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -141,7 +141,7 @@ func TestIntegration_ListZones(t *testing.T) {
 
 	// Make test request
 	req := httptest.NewRequest("GET", "/dnszone", nil)
-	req.Header.Set("Authorization", "Bearer test-key-123")
+	req.Header.Set("AccessKey", "test-key-123")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -190,7 +190,7 @@ func TestIntegration_GetZone(t *testing.T) {
 
 	// Request specific zone
 	req := httptest.NewRequest("GET", fmt.Sprintf("/dnszone/%d", zoneID), nil)
-	req.Header.Set("Authorization", "Bearer test-key-123")
+	req.Header.Set("AccessKey", "test-key-123")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -239,7 +239,7 @@ func TestIntegration_ListRecords(t *testing.T) {
 
 	// Request records
 	req := httptest.NewRequest("GET", fmt.Sprintf("/dnszone/%d/records", zoneID), nil)
-	req.Header.Set("Authorization", "Bearer test-key-123")
+	req.Header.Set("AccessKey", "test-key-123")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -289,7 +289,7 @@ func TestIntegration_AddRecord(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("POST", fmt.Sprintf("/dnszone/%d/records", zoneID), bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer test-key-123")
+	req.Header.Set("AccessKey", "test-key-123")
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -344,7 +344,7 @@ func TestIntegration_DeleteRecord(t *testing.T) {
 
 	// Delete the record
 	req := httptest.NewRequest("DELETE", fmt.Sprintf("/dnszone/%d/records/%d", zoneID, recordID), nil)
-	req.Header.Set("Authorization", "Bearer test-key-123")
+	req.Header.Set("AccessKey", "test-key-123")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -411,7 +411,7 @@ func TestIntegration_Unauthorized_InvalidKey(t *testing.T) {
 
 	// Request with invalid key
 	req := httptest.NewRequest("GET", "/dnszone", nil)
-	req.Header.Set("Authorization", "Bearer invalid-key-xyz")
+	req.Header.Set("AccessKey", "invalid-key-xyz")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -451,7 +451,7 @@ func TestIntegration_Forbidden_WrongZone(t *testing.T) {
 
 	// Try to access zone with permission
 	req := httptest.NewRequest("GET", fmt.Sprintf("/dnszone/%d/records", zoneID1), nil)
-	req.Header.Set("Authorization", "Bearer valid-key")
+	req.Header.Set("AccessKey", "valid-key")
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, req)
@@ -462,7 +462,7 @@ func TestIntegration_Forbidden_WrongZone(t *testing.T) {
 
 	// Try to access zone without permission (not in storage permissions)
 	req2 := httptest.NewRequest("GET", fmt.Sprintf("/dnszone/%d/records", zoneID2), nil)
-	req2.Header.Set("Authorization", "Bearer valid-key")
+	req2.Header.Set("AccessKey", "valid-key")
 	w2 := httptest.NewRecorder()
 
 	router.ServeHTTP(w2, req2)
@@ -504,7 +504,7 @@ func TestIntegration_Forbidden_WrongRecordType(t *testing.T) {
 	}
 
 	req := httptest.NewRequest("POST", fmt.Sprintf("/dnszone/%d/records", zoneID), bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer restricted-key")
+	req.Header.Set("AccessKey", "restricted-key")
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -229,7 +229,7 @@ func proxyRequest(t *testing.T, method, path, apiKey string, body []byte) *http.
 	}
 
 	req, _ := http.NewRequest(method, proxyURL+path, bodyReader)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("AccessKey", apiKey)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
Replace Authorization: Bearer with AccessKey header format to match bunny.net API authentication pattern.

## Summary
- Update auth middleware to use AccessKey header
- Update admin token auth to use AccessKey header
- Update all tests (unit, integration, E2E)
- Update documentation with new header format

## Breaking Change
This changes the authentication header format. Clients must update from:
  Authorization: Bearer <key>
To:
  AccessKey: <key>

This is acceptable as the project is pre-1.0.