### PR TITLE
build: Update Dockerfile for CGO-free build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build stage
 FROM golang:1.24-alpine AS builder
 
-# Install build dependencies (including gcc and musl-dev for CGO/SQLite)
-RUN apk add --no-cache git gcc musl-dev
+# Install build dependencies
+RUN apk add --no-cache git
 
 WORKDIR /app
 
@@ -15,11 +15,11 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the binary (CGO enabled for SQLite)
-RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o bunny-api-proxy ./cmd/bunny-api-proxy
+# Build the binary (CGO disabled - using pure Go SQLite driver)
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s -w' -o bunny-api-proxy ./cmd/bunny-api-proxy
 
 # Final stage
-FROM alpine:latest
+FROM alpine:3.21
 
 # Install ca-certificates for HTTPS
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
## Summary
- Remove gcc and musl-dev build dependencies (no longer needed with pure Go SQLite driver)
- Change CGO_ENABLED from 1 to 0 for pure Go builds
- Simplify ldflags to -s -w (strip symbols and debug info)
- Pin Alpine base image to 3.21 for reproducibility

## Related
- Closes #134
- Part of #132 (SQLite driver migration)

## Validation
- Dockerfile syntax verified
- Build dependencies simplified for pure Go builds
- Uses modernc.org/sqlite which is pure Go implementation