### PR TITLE
docs: Update all documentation for API-only architecture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -68,10 +68,9 @@ internal/               # Private application code
   proxy/                # Core proxy logic
   auth/                 # Key validation, permissions
   storage/              # SQLite operations
-  admin/                # Admin UI handlers
+  admin/                # Admin API handlers
   bunny/                # bunny.net API client
   testutil/mockbunny/   # Mock server for testing
-web/templates/          # HTML templates
 ```
 
 ## Key Files


### PR DESCRIPTION
## Summary

- Update ARCHITECTURE.md to reflect API-only architecture (no Web UI)
- Update docs/API.md to remove Admin Web UI section and update authentication
- Update docs/DEPLOYMENT.md to remove ADMIN_PASSWORD/ENCRYPTION_KEY and add bootstrap flow
- Update docs/SECURITY.md to remove session management and update to hash-based storage
- Update examples/README.md to use new env vars and bootstrap flow
- Update .claude/CLAUDE.md to remove web/templates/ from project structure

## Changes

Removes all references to:
- Web UI / Admin UI
- ADMIN_PASSWORD environment variable
- ENCRYPTION_KEY environment variable
- Session-based authentication
- HTML templates

Updates to reflect:
- Bootstrap via bunny.net master API key
- AccessKey header authentication
- Hash-based master key storage
- New environment variables (LOG_LEVEL, LISTEN_ADDR, DATABASE_PATH, BUNNY_API_URL)

## Test plan

- [x] Verify all documentation files are updated
- [x] Verify no references to ADMIN_PASSWORD, ENCRYPTION_KEY, or Web UI remain
- [x] Verify bootstrap flow is documented correctly

https://claude.ai/code/session_01FFaDwAAM6w1WK8ZqzVhVGe