### PR TITLE
ci: Skip docs-only PRs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '.claude/**'
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
Adds `paths-ignore` to the `pull_request` trigger so documentation-only PRs skip the full CI suite.

Previously, `paths-ignore` only applied to `push` events, causing docs PRs to run all tests, lint, security scan, docker build, and E2E tests unnecessarily.