### PR TITLE
docs: Fix remaining incorrect bootstrap endpoint references

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -44,19 +44,19 @@ For initial setup, use your bunny.net master API key with the bootstrap endpoint
 
 ### Bootstrap (First Setup)
 
-#### POST /admin/api/bootstrap
+#### POST /admin/api/tokens (Bootstrap)
 
-Create the first admin token using your bunny.net master API key. This endpoint only works when no admin tokens exist yet.
+Create the first admin token using your bunny.net master API key. During bootstrap (when no admin tokens exist), use your master key and set `is_admin: true`.
 
 **Authentication:** bunny.net master API key in AccessKey header
-**Response:** 201 Created or 409 Conflict (if admin tokens already exist)
+**Response:** 201 Created or 403 Forbidden (if master key locked out after admin exists)
 
 **Example Request:**
 ```bash
-curl -X POST http://localhost:8080/admin/api/bootstrap \
+curl -X POST http://localhost:8080/admin/api/tokens \
   -H "AccessKey: your-bunny-net-master-api-key" \
   -H "Content-Type: application/json" \
-  -d '{"name": "initial-admin-token"}'
+  -d '{"name": "initial-admin-token", "is_admin": true}'
 ```
 
 **Example Response:**
@@ -64,7 +64,8 @@ curl -X POST http://localhost:8080/admin/api/bootstrap \
 {
   "id": 1,
   "name": "initial-admin-token",
-  "token": "generated-admin-token-value"
+  "token": "generated-admin-token-value",
+  "is_admin": true
 }
 ```
 
@@ -510,16 +511,17 @@ Example configuration for an ACME client using the Bunny API Proxy:
 
 ```bash
 # 1. Bootstrap: Create first admin token using bunny.net master key
-curl -X POST http://localhost:8080/admin/api/bootstrap \
+curl -X POST http://localhost:8080/admin/api/tokens \
   -H "AccessKey: your-bunny-net-master-api-key" \
   -H "Content-Type: application/json" \
-  -d '{"name": "initial-admin"}'
+  -d '{"name": "initial-admin", "is_admin": true}'
 
 # Response:
 # {
 #   "id": 1,
 #   "name": "initial-admin",
-#   "token": "admin-token-value"
+#   "token": "admin-token-value",
+#   "is_admin": true
 # }
 
 # 2. Create a scoped key restricted to TXT record management for DNS-01

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,26 +44,26 @@ Example permission model:
 
 ### 2.1 Bootstrap Authentication
 
-**Flow**: bunny.net Master API Key → Validate with bunny.net → Create First Admin Token
+**Flow**: bunny.net Master API Key → Create First Admin Token
 
 #### Bootstrap Mechanism
-- **Endpoint**: `POST /admin/api/bootstrap`
+- **Endpoint**: `POST /admin/api/tokens` with `is_admin: true`
 - **Input**: bunny.net master API key in `AccessKey` header
-- **Validation**: The proxy validates the key by making a test request to bunny.net
-- **Availability**: Only works when no admin tokens exist in the database
-- **Prevention**: Once an admin token exists, bootstrap is disabled
+- **Validation**: The proxy checks if the key matches the stored master key hash
+- **Availability**: Master key authentication only works when no admin tokens exist
+- **Prevention**: Once an admin token exists, master key is locked out
 
 **Security notes**:
-- Bootstrap requires a valid bunny.net master API key
-- The master key is validated against bunny.net's API
-- Once bootstrap completes, this endpoint returns 409 Conflict
+- Bootstrap requires the bunny.net master API key
+- The master key hash is stored when setting up the proxy
+- Once an admin token exists, master key returns 403 Forbidden
 
 ### 2.2 Admin API Authentication
 
 **Flow**: AccessKey Token → Hash Validation → Request Processing
 
 #### AccessKey Token Authentication
-- **Endpoint**: Any `/admin/api/*` endpoint (except bootstrap)
+- **Endpoint**: Any `/admin/api/*` endpoint
 - **Header format**: `AccessKey: <token>`
 - **Token validation**:
   1. Token is hashed with SHA-256

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,10 +27,10 @@ docker-compose up -d
 curl http://localhost:8080/health
 
 # 5. Bootstrap with your bunny.net master API key
-curl -X POST http://localhost:8080/admin/api/bootstrap \
+curl -X POST http://localhost:8080/admin/api/tokens \
   -H "AccessKey: your-bunny-net-master-api-key" \
   -H "Content-Type: application/json" \
-  -d '{"name": "initial-admin"}'
+  -d '{"name": "initial-admin", "is_admin": true}'
 
 # View logs
 docker-compose logs -f bunny-api-proxy


### PR DESCRIPTION
Fixes remaining incorrect `/admin/api/bootstrap` references in:

- docs/API.md
- docs/SECURITY.md  
- examples/README.md

Changed to `POST /admin/api/tokens` with `is_admin: true` to match actual API.