### PR TITLE
feat: Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Go modules (go.mod)
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Auto-assign PRs to make them more visible
+    assignees:
+      - "sipico"
+    # Group minor and patch updates to reduce PR noise
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker base images (Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "sipico"
+
+  # Docker images in .claude/docker/ directory
+  - package-ecosystem: "docker"
+    directory: "/.claude/docker"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "sipico"
+
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "sipico"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to enable automated dependency updates across the project.

## What This Enables

Dependabot will automatically:
- Check for updates weekly (every Monday)
- Create pull requests when updates are available
- Group minor/patch updates to reduce PR noise
- Track updates for:
  - **Go modules** (chi, sqlite, golang.org/x packages)
  - **Docker base images** (golang:1.25-alpine, distroless images)
  - **GitHub Actions** (actions/checkout, actions/setup-go, etc.)

## Configuration Details

- **Schedule**: Weekly checks (reduces noise while staying current)
- **Auto-assignment**: PRs automatically assigned to @sipico
- **Grouping**: Minor/patch updates grouped together to reduce PR count
- **Multiple Directories**: Tracks both main Dockerfile and .claude/docker/* files

## Benefits

1. **Security**: Automatic security patches and vulnerability fixes
2. **Maintenance**: Stay current with latest stable versions
3. **Automation**: No manual dependency checking needed
4. **Visibility**: All updates come as reviewable PRs with changelogs

## How It Works

Once merged, Dependabot will:
1. Check for updates every Monday
2. Create PRs with version bump and changelog
3. PRs will trigger CI to validate changes
4. You review and merge when ready

## Testing

After merge, Dependabot will start running within 24 hours. You can manually trigger it from the repository's "Insights > Dependency graph > Dependabot" page.

https://claude.ai/code/session_01G6pekvjzReYMEaSjgyyPzQ