### PR TITLE
chore(deps): Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -90,10 +90,10 @@ jobs:
     needs: [test, lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -108,14 +108,14 @@ jobs:
         run: go build -o mockbunny ./cmd/mockbunny
 
       - name: Upload proxy binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bunny-api-proxy
           path: bunny-api-proxy
           retention-days: 7
 
       - name: Upload mockbunny binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mockbunny
           path: mockbunny
@@ -127,7 +127,7 @@ jobs:
     needs: [test, lint, build]  # Wait for binary to be built
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create build contexts for pre-built binaries
         run: |
@@ -135,13 +135,13 @@ jobs:
           mkdir -p ci-build/proxy ci-build/mockbunny
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bunny-api-proxy
           path: ci-build/proxy
 
       - name: Download mockbunny binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mockbunny
           path: ci-build/mockbunny
@@ -160,7 +160,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build proxy Docker image (using pre-built binary)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ci-build/proxy
           file: .claude/docker/Dockerfile.prebuilt
@@ -169,7 +169,7 @@ jobs:
           tags: bunny-api-proxy:test
 
       - name: Build mockbunny Docker image (using pre-built binary)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ci-build/mockbunny
           file: .claude/docker/Dockerfile.mockbunny.prebuilt
@@ -178,7 +178,7 @@ jobs:
           tags: mockbunny:test
 
       - name: Build test-runner Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: .claude/docker/Dockerfile.testrunner
@@ -196,7 +196,7 @@ jobs:
           ls -lh /tmp/*.tar
 
       - name: Upload Docker images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docker-images
           path: |
@@ -212,10 +212,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Docker images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: docker-images
           path: /tmp
@@ -271,7 +271,7 @@ jobs:
 
       - name: Upload E2E logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-logs
           path: e2e-logs/
@@ -293,10 +293,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Docker images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: docker-images
           path: /tmp
@@ -349,7 +349,7 @@ jobs:
 
       - name: Upload E2E logs (Real API)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-logs-real-api
           path: e2e-logs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -32,7 +32,7 @@ jobs:
         run: go build -o bunny-api-proxy ./cmd/bunny-api-proxy
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bunny-api-proxy
           path: bunny-api-proxy
@@ -44,13 +44,13 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create build context
         run: mkdir -p ci-build/proxy
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bunny-api-proxy
           path: ci-build/proxy
@@ -73,7 +73,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ci-build/proxy
           file: .claude/docker/Dockerfile.prebuilt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       micro: ${{ steps.calver.outputs.micro }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for tag analysis
 
@@ -71,10 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -104,10 +104,10 @@ jobs:
     needs: [test, lint]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -117,7 +117,7 @@ jobs:
         run: go build -o bunny-api-proxy ./cmd/bunny-api-proxy
 
       - name: Upload proxy binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bunny-api-proxy
           path: bunny-api-proxy
@@ -129,13 +129,13 @@ jobs:
     needs: [calculate-version, build-binaries]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create build context
         run: mkdir -p ci-build/proxy
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bunny-api-proxy
           path: ci-build/proxy
@@ -155,7 +155,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ci-build/proxy
           file: .claude/docker/Dockerfile.prebuilt
@@ -179,7 +179,7 @@ jobs:
     needs: [calculate-version, publish-docker]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Update all GitHub Actions to their latest major versions across all workflows:

- **actions/checkout**: v4 → v6 (supersedes #183)
- **actions/download-artifact**: v4 → v7 (supersedes #182)
- **actions/setup-go**: v5 → v6 (supersedes #181)
- **docker/build-push-action**: v5 → v6 (supersedes #180)
- **actions/upload-artifact**: v4 → v6 (supersedes #179)

## Background

These updates were originally proposed by Dependabot in PRs #179-#183, but all failed CI due to GitHub's security feature that prevents secrets from being exposed to Dependabot pull requests. The E2E tests require `MOCKBUNNY_API_TEST_KEY` secret which is not available to Dependabot PRs.

By re-implementing these changes manually on a non-Dependabot branch, CI will have access to required secrets and tests should pass.

## Changes

- Updated `.github/workflows/ci.yml` - All action versions
- Updated `.github/workflows/publish.yml` - All action versions  
- Updated `.github/workflows/release.yml` - All action versions

## Test Plan

- [x] All workflow files updated
- [ ] CI passes with new action versions
- [ ] E2E tests succeed with secrets available

## References

- Closes #183
- Closes #182
- Closes #181
- Closes #180
- Closes #179

https://claude.ai/code/session_016u4GzxdXuQucb3RmrchN84