### PR TITLE
Security: Harden master key lockout and key generation

### DIFF
--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -471,12 +471,18 @@ func TestHandleDeleteToken(t *testing.T) {
 func TestGenerateRandomKey(t *testing.T) {
 	t.Parallel()
 	// Test that generateRandomKey produces keys of correct length
-	key1 := generateRandomKey(32)
+	key1, err := generateRandomKey(32)
+	if err != nil {
+		t.Fatalf("generateRandomKey failed: %v", err)
+	}
 	if len(key1) != 32 {
 		t.Errorf("expected key length 32, got %d", len(key1))
 	}
 
-	key2 := generateRandomKey(32)
+	key2, err := generateRandomKey(32)
+	if err != nil {
+		t.Fatalf("generateRandomKey failed: %v", err)
+	}
 	if len(key2) != 32 {
 		t.Errorf("expected key length 32, got %d", len(key2))
 	}


### PR DESCRIPTION
Closes #203

## Summary
- Changed generateRandomKey to return (string, error), removed insecure time-based fallback
- Added bootstrap state check to TokenAuthMiddleware to reject master key post-bootstrap
- Removed redundant master key check from HandleCreateUnifiedToken

## Test plan
- [x] Verify generateRandomKey returns error instead of fallback
- [x] Verify master key rejected on admin endpoints after bootstrap
- [x] Verify master key still works during bootstrap (UNCONFIGURED)
- [x] All existing tests pass

https://claude.ai/code/session_01113tBauUgYsMDNeVTXdzQW