### PR TITLE
Security: Add request body size limits and fix error comparisons

### DIFF
--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -157,7 +158,7 @@ func (h *Handler) HandleDeleteToken(w http.ResponseWriter, r *http.Request) {
 
 	err = h.storage.DeleteAdminToken(r.Context(), id)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -363,7 +364,7 @@ func (h *Handler) HandleCreateUnifiedToken(w http.ResponseWriter, r *http.Reques
 	// Create the token
 	token, err := h.storage.CreateToken(ctx, req.Name, req.IsAdmin, keyHash)
 	if err != nil {
-		if err == storage.ErrDuplicate {
+		if errors.Is(err, storage.ErrDuplicate) {
 			WriteErrorWithHint(w, http.StatusConflict, "duplicate_token",
 				"A token with this hash already exists", "Try creating the token again.")
 			return
@@ -431,7 +432,7 @@ func (h *Handler) HandleGetUnifiedToken(w http.ResponseWriter, r *http.Request) 
 
 	token, err := h.storage.GetTokenByID(ctx, id)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -480,7 +481,7 @@ func (h *Handler) HandleDeleteUnifiedToken(w http.ResponseWriter, r *http.Reques
 	// Get the token to check if it's an admin
 	token, err := h.storage.GetTokenByID(ctx, id)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -507,7 +508,7 @@ func (h *Handler) HandleDeleteUnifiedToken(w http.ResponseWriter, r *http.Reques
 
 	err = h.storage.DeleteToken(ctx, id)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -551,7 +552,7 @@ func (h *Handler) HandleAddTokenPermission(w http.ResponseWriter, r *http.Reques
 	// Verify token exists
 	token, err := h.storage.GetTokenByID(ctx, tokenID)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -639,7 +640,7 @@ func (h *Handler) HandleDeleteTokenPermission(w http.ResponseWriter, r *http.Req
 	// Verify token exists
 	_, err = h.storage.GetTokenByID(ctx, tokenID)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Token not found")
 			return
 		}
@@ -651,7 +652,7 @@ func (h *Handler) HandleDeleteTokenPermission(w http.ResponseWriter, r *http.Req
 	// Delete the permission
 	err = h.storage.RemovePermission(ctx, permID)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, ErrCodeNotFound, "Permission not found")
 			return
 		}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -20,6 +20,7 @@ func (h *Handler) NewRouter() chi.Router {
 	r.Use(internalMiddleware.RequestID)                             // Request ID first
 	r.Use(internalMiddleware.HTTPLogging(h.logger, adminAllowlist)) // Logging with allowlist
 	r.Use(middleware.Recoverer)                                     // Panic recovery
+	r.Use(internalMiddleware.MaxBodySize(1 << 20))                  // 1MB limit
 
 	// Public endpoints (no auth)
 	r.Get("/health", h.HandleHealth)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -69,7 +70,7 @@ func (m *Authenticator) Authenticate(next http.Handler) http.Handler {
 
 		token, err := m.tokens.GetTokenByHash(ctx, keyHash)
 		if err != nil {
-			if err == storage.ErrNotFound {
+			if errors.Is(err, storage.ErrNotFound) {
 				writeJSONError(w, http.StatusUnauthorized, "invalid API key")
 				return
 			}
@@ -206,7 +207,7 @@ func Middleware(v *Validator) func(http.Handler) http.Handler {
 			// Validate the key
 			keyInfo, err := v.ValidateKey(r.Context(), apiKey)
 			if err != nil {
-				if err == ErrInvalidKey {
+				if errors.Is(err, ErrInvalidKey) {
 					writeJSONError(w, http.StatusUnauthorized, "invalid API key")
 					return
 				}

--- a/internal/middleware/body_limit.go
+++ b/internal/middleware/body_limit.go
@@ -1,0 +1,15 @@
+package middleware
+
+import "net/http"
+
+// MaxBodySize returns middleware that limits request body size.
+// Requests exceeding maxBytes will receive a 413 Request Entity Too Large response
+// when the handler attempts to read beyond the limit.
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/body_limit_test.go
+++ b/internal/middleware/body_limit_test.go
@@ -1,0 +1,106 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMaxBodySize(t *testing.T) {
+	tests := []struct {
+		name          string
+		limit         int64
+		bodySize      int
+		shouldSucceed bool
+	}{
+		{
+			name:          "body under limit",
+			limit:         1024,
+			bodySize:      512,
+			shouldSucceed: true,
+		},
+		{
+			name:          "body exactly at limit",
+			limit:         1024,
+			bodySize:      1024,
+			shouldSucceed: true,
+		},
+		{
+			name:          "body over limit",
+			limit:         1024,
+			bodySize:      2048,
+			shouldSucceed: false,
+		},
+		{
+			name:          "empty body",
+			limit:         1024,
+			bodySize:      0,
+			shouldSucceed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test handler that reads the body
+			readError := false
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.ReadAll(r.Body)
+				if err != nil {
+					readError = true
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Wrap handler with MaxBodySize middleware
+			wrappedHandler := MaxBodySize(tt.limit)(handler)
+
+			// Create request with test body
+			body := bytes.NewReader(make([]byte, tt.bodySize))
+			req := httptest.NewRequest("POST", "/test", body)
+			w := httptest.NewRecorder()
+
+			// Execute request
+			wrappedHandler.ServeHTTP(w, req)
+
+			// Verify behavior
+			if tt.shouldSucceed && readError {
+				t.Errorf("expected successful read, got error")
+			}
+			if !tt.shouldSucceed && !readError {
+				t.Errorf("expected read error, got none")
+			}
+		})
+	}
+}
+
+func TestMaxBodySizeAllowsSmallBodies(t *testing.T) {
+	// Test that small bodies pass through successfully
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if len(data) != 50 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrappedHandler := MaxBodySize(1024)(handler)
+
+	// Create request with small body
+	body := bytes.NewReader(make([]byte, 50))
+	req := httptest.NewRequest("POST", "/test", body)
+	w := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status OK, got %d", w.Code)
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -18,6 +18,7 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	// Apply middlewares in order
 	r.Use(middleware.RequestID)                // Add request ID first
 	r.Use(middleware.HTTPLogging(logger, nil)) // Log with no allowlist (DNS API has no secrets)
+	r.Use(middleware.MaxBodySize(1 << 20))     // 1MB limit
 	r.Use(authMiddleware)                      // Auth after logging
 
 	// Wire handler methods to routes


### PR DESCRIPTION
Closes #204

## Summary
- Added MaxBodySize middleware (1MB limit) applied to admin and proxy routers
- Fixed all err == sentinel comparisons to use errors.Is()

## Test plan
- [x] Body limit middleware tests pass
- [x] All existing tests pass
- [x] Linter passes

https://claude.ai/code/session_01113tBauUgYsMDNeVTXdzQW