### PR TITLE
Performance: Use SQL WHERE clause and indexed hash lookup

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -54,6 +54,7 @@ type Storage interface {
 	// Unified token operations (Issue 147)
 	CreateToken(ctx context.Context, name string, isAdmin bool, keyHash string) (*storage.Token, error)
 	GetTokenByID(ctx context.Context, id int64) (*storage.Token, error)
+	GetTokenByHash(ctx context.Context, keyHash string) (*storage.Token, error)
 	ListTokens(ctx context.Context) ([]*storage.Token, error)
 	DeleteToken(ctx context.Context, id int64) error
 	CountAdminTokens(ctx context.Context) (int, error)

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -148,6 +148,10 @@ func (m *mockStorageForAdminTest) GetPermissionsForToken(ctx context.Context, to
 	return make([]*storage.Permission, 0), nil
 }
 
+func (m *mockStorageForAdminTest) GetTokenByHash(ctx context.Context, keyHash string) (*storage.Token, error) {
+	return nil, storage.ErrNotFound
+}
+
 // TestContextHelpers tests the context helper functions
 func TestContextHelpers(t *testing.T) {
 	t.Parallel()

--- a/internal/admin/api_test.go
+++ b/internal/admin/api_test.go
@@ -119,6 +119,9 @@ func (m *mockStorageWithTokenCRUD) GetPermissionsForToken(ctx context.Context, t
 	return make([]*storage.Permission, 0), nil
 }
 
+func (m *mockStorageWithTokenCRUD) GetTokenByHash(ctx context.Context, keyHash string) (*storage.Token, error) {
+	return nil, storage.ErrNotFound
+}
 func TestHandleSetLogLevel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/admin/health_test.go
+++ b/internal/admin/health_test.go
@@ -100,6 +100,10 @@ func (m *mockStorage) GetPermissionsForToken(ctx context.Context, tokenID int64)
 	return make([]*storage.Permission, 0), nil
 }
 
+func (m *mockStorage) GetTokenByHash(ctx context.Context, keyHash string) (*storage.Token, error) {
+	return nil, storage.ErrNotFound
+}
+
 // failingWriter is a ResponseWriter that fails on Write to test error handling
 type failingWriter struct {
 	header http.Header

--- a/internal/admin/token_auth.go
+++ b/internal/admin/token_auth.go
@@ -97,23 +97,8 @@ func (h *Handler) TokenAuthMiddleware(next http.Handler) http.Handler {
 // validateUnifiedToken validates a token against the unified token system.
 // Returns the token if valid, or nil if not found.
 func (h *Handler) validateUnifiedToken(ctx context.Context, token string) (*storage.Token, error) {
-	// Hash the provided token and look it up
-	// The storage layer handles the hashing
-	tokens, err := h.storage.ListTokens(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Hash the provided token for comparison
 	keyHash := auth.HashToken(token)
-
-	for _, t := range tokens {
-		if t.KeyHash == keyHash {
-			return t, nil
-		}
-	}
-
-	return nil, storage.ErrNotFound
+	return h.storage.GetTokenByHash(ctx, keyHash)
 }
 
 // GetTokenInfoFromContext retrieves token info from context


### PR DESCRIPTION
Closes #206

## Summary
- ListScopedKeys and ListAdminTokens now use SQL WHERE instead of Go filtering
- validateUnifiedToken uses indexed GetTokenByHash instead of ListTokens

## Test plan
- [x] All existing storage and admin tests pass
- [x] Race detector passes

https://claude.ai/code/session_01113tBauUgYsMDNeVTXdzQW