### PR TITLE
CI: Prevent concurrent E2E Real API test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,9 @@ jobs:
     needs: [test, lint, docker, e2e-test]  # Wait for docker build and mock tests to pass
     # Only run on PRs to main
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    concurrency:
+      group: e2e-real-api
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Add `concurrency` group to the E2E Real API test job so only one runs at a time
- All E2E Real API runs share the same bunny.net test account — concurrent runs create/delete zones that interfere with each other, causing cascading "Account is not empty!" failures
- Uses `cancel-in-progress: false` so queued runs execute in order rather than being cancelled

## Root cause
When multiple PRs trigger CI simultaneously, each spawns an E2E Real API run that creates test zones on the same bunny.net account. One run's cleanup deletes zones while another run expects them, or one run sees leftover zones from another and fails the "empty account" precondition check.

## Test plan
- [x] Verify the change is syntactically valid YAML
- [ ] Merge and re-trigger the 4 pending code review PRs simultaneously to confirm they no longer interfere

https://claude.ai/code/session_01113tBauUgYsMDNeVTXdzQW