### PR TITLE
fix(docker): install git in test runner for unique zone names

### DIFF
--- a/.claude/docker/Dockerfile.testrunner
+++ b/.claude/docker/Dockerfile.testrunner
@@ -3,6 +3,8 @@
 
 FROM golang:1.25.7-alpine
 
+RUN apk add --no-cache git
+
 WORKDIR /app
 
 # Copy go mod files


### PR DESCRIPTION
## Summary
- Adds `git` to the Alpine-based test runner Docker image so `getCommitHash()` uses the real git hash instead of a timestamp fallback
- This produces more unique zone name suffixes in E2E mock tests, matching real API test behavior

Fixes #223

## Test plan
- [ ] CI passes (Dockerfile change only, no Go code affected)
- [ ] E2E mock tests produce unique zone name suffixes based on git commit hash

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi