### PR TITLE
fix(mockbunny): match real API timestamp format with sub-second precision

### DIFF
--- a/internal/testutil/mockbunny/types.go
+++ b/internal/testutil/mockbunny/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // MockBunnyTime wraps time.Time to serialize in bunny.net's format
-// (without timezone suffix, matching real API behavior).
+// (with sub-second precision and Z suffix, matching real API behavior).
 //
 //nolint:revive // MockBunnyTime is descriptive and distinguishes from time.Time
 type MockBunnyTime struct {
@@ -18,14 +18,14 @@ type MockBunnyTime struct {
 }
 
 // MarshalJSON implements json.Marshaler for MockBunnyTime.
-// It returns timestamps in "2006-01-02T15:04:05" format (no timezone),
+// It returns timestamps in "2006-01-02T15:04:05.0000000Z" format (with sub-second precision and Z suffix),
 // matching bunny.net's actual API behavior.
 func (t MockBunnyTime) MarshalJSON() ([]byte, error) {
 	if t.IsZero() {
 		return []byte("null"), nil
 	}
-	// Format without timezone suffix to match real bunny.net API
-	formatted := `"` + t.UTC().Format("2006-01-02T15:04:05") + `"`
+	// Format with sub-second precision and Z suffix to match real bunny.net API creation endpoint
+	formatted := `"` + t.UTC().Format("2006-01-02T15:04:05.0000000") + `Z"`
 	return []byte(formatted), nil
 }
 

--- a/internal/testutil/mockbunny/types_test.go
+++ b/internal/testutil/mockbunny/types_test.go
@@ -161,9 +161,9 @@ func TestMockBunnyTime_MarshalJSON(t *testing.T) {
 			expected: `null`,
 		},
 		{
-			name:     "timestamp marshals without timezone",
+			name:     "timestamp marshals with sub-second precision and Z",
 			time:     MockBunnyTime{Time: time.Date(2026, 2, 3, 14, 7, 45, 0, time.UTC)},
-			expected: `"2026-02-03T14:07:45"`,
+			expected: `"2026-02-03T14:07:45.0000000Z"`,
 		},
 	}
 
@@ -248,8 +248,8 @@ func TestMockBunnyTime_RoundTrip(t *testing.T) {
 		t.Fatalf("Marshal error: %v", err)
 	}
 
-	// Should produce format without timezone
-	expected := `"2026-02-03T14:07:45"`
+	// Should produce format with sub-second precision and Z
+	expected := `"2026-02-03T14:07:45.0000000Z"`
 	if string(marshaled) != expected {
 		t.Errorf("Marshaled = %s, want %s", marshaled, expected)
 	}


### PR DESCRIPTION
## Summary
- Changes `MockBunnyTime.MarshalJSON` to output `2026-02-03T14:07:45.0000000Z` format (7-digit sub-second precision + Z suffix)
- Matches the real Bunny.net API creation endpoint timestamp format
- Updates corresponding tests for new format

Fixes #225

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [x] `golangci-lint run ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi