### PR TITLE
fix(mockbunny): use underscore separator in ErrorKey to match real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -183,11 +183,11 @@ func (s *Server) handleAddRecord(w http.ResponseWriter, r *http.Request) {
 	// Validate required fields
 	// Type is validated implicitly (must be provided as int 0-12)
 	if req.Name == "" {
-		s.writeError(w, http.StatusBadRequest, "validation.error", "Name", "Name is required")
+		s.writeError(w, http.StatusBadRequest, "validation_error", "Name", "Name is required")
 		return
 	}
 	if req.Value == "" {
-		s.writeError(w, http.StatusBadRequest, "validation.error", "Value", "Value is required")
+		s.writeError(w, http.StatusBadRequest, "validation_error", "Value", "Value is required")
 		return
 	}
 
@@ -243,7 +243,7 @@ func (s *Server) handleCreateZone(w http.ResponseWriter, r *http.Request) {
 
 	// Validate domain
 	if req.Domain == "" {
-		s.writeError(w, http.StatusBadRequest, "validation.error", "Domain", "Domain is required")
+		s.writeError(w, http.StatusBadRequest, "validation_error", "Domain", "Domain is required")
 		return
 	}
 

--- a/internal/testutil/mockbunny/handlers_test.go
+++ b/internal/testutil/mockbunny/handlers_test.go
@@ -597,8 +597,8 @@ func TestHandleCreateZone_EmptyDomain(t *testing.T) {
 		t.Fatalf("failed to decode error response: %v", err)
 	}
 
-	if errResp.ErrorKey != "validation.error" {
-		t.Errorf("expected error key validation.error, got %s", errResp.ErrorKey)
+	if errResp.ErrorKey != "validation_error" {
+		t.Errorf("expected error key validation_error, got %s", errResp.ErrorKey)
 	}
 	if errResp.Field != "Domain" {
 		t.Errorf("expected field Domain, got %s", errResp.Field)


### PR DESCRIPTION
## Summary
- Changes `"validation.error"` to `"validation_error"` in all 3 mockbunny validation error responses
- Updates test assertion in `TestHandleCreateZone_EmptyDomain` to match

Fixes #215

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [x] `golangci-lint run ./internal/testutil/mockbunny/...` clean
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi