### PR TITLE
fix(mockbunny): check Value before Name to match real API validation order

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -182,12 +182,12 @@ func (s *Server) handleAddRecord(w http.ResponseWriter, r *http.Request) {
 
 	// Validate required fields
 	// Type is validated implicitly (must be provided as int 0-12)
-	if req.Name == "" {
-		s.writeError(w, http.StatusBadRequest, "validation_error", "Name", "Name is required")
-		return
-	}
 	if req.Value == "" {
 		s.writeError(w, http.StatusBadRequest, "validation_error", "Value", "Value is required")
+		return
+	}
+	if req.Name == "" {
+		s.writeError(w, http.StatusBadRequest, "validation_error", "Name", "Name is required")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Swaps the validation order in `handleAddRecord` so `Value` is checked before `Name`
- Matches the real Bunny.net API which rejects on `Value` first when both fields are empty

Fixes #216

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [x] Existing tests for MissingName and MissingValue still pass (each only omits one field)
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi