### PR TITLE
fix(mockbunny): use hostmaster@bunny.net for SoaEmail to match real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -273,7 +273,7 @@ func (s *Server) handleCreateZone(w http.ResponseWriter, r *http.Request) {
 		CustomNameserversEnabled: false,
 		Nameserver1:              "ns1.bunny.net",
 		Nameserver2:              "ns2.bunny.net",
-		SoaEmail:                 "admin@" + req.Domain,
+		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)
 		DnsSecEnabled:            false,

--- a/internal/testutil/mockbunny/handlers_test.go
+++ b/internal/testutil/mockbunny/handlers_test.go
@@ -558,8 +558,8 @@ func TestHandleCreateZone_Success(t *testing.T) {
 	if zone.Nameserver2 != "ns2.bunny.net" {
 		t.Errorf("expected nameserver2 ns2.bunny.net, got %s", zone.Nameserver2)
 	}
-	if zone.SoaEmail != "admin@test.xyz" {
-		t.Errorf("expected SoaEmail admin@test.xyz, got %s", zone.SoaEmail)
+	if zone.SoaEmail != "hostmaster@bunny.net" {
+		t.Errorf("expected SoaEmail hostmaster@bunny.net, got %s", zone.SoaEmail)
 	}
 	if zone.CertificateKeyType != 0 { // 0 = Ecdsa
 		t.Errorf("expected CertificateKeyType Ecdsa (0), got %d", zone.CertificateKeyType)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -134,7 +134,7 @@ func (s *Server) AddZone(domain string) int64 {
 		CustomNameserversEnabled: false,
 		Nameserver1:              "ns1.bunny.net",
 		Nameserver2:              "ns2.bunny.net",
-		SoaEmail:                 "admin@" + domain,
+		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)
 		DnsSecEnabled:            false,

--- a/internal/testutil/mockbunny/server_test.go
+++ b/internal/testutil/mockbunny/server_test.go
@@ -162,8 +162,8 @@ func TestAddZone(t *testing.T) {
 	if zone.Domain != "example.com" {
 		t.Errorf("expected example.com, got %s", zone.Domain)
 	}
-	if zone.SoaEmail != "admin@example.com" {
-		t.Errorf("expected admin@example.com, got %s", zone.SoaEmail)
+	if zone.SoaEmail != "hostmaster@bunny.net" {
+		t.Errorf("expected hostmaster@bunny.net, got %s", zone.SoaEmail)
 	}
 	if zone.Nameserver1 != "ns1.bunny.net" {
 		t.Errorf("expected ns1.bunny.net, got %s", zone.Nameserver1)


### PR DESCRIPTION
## Summary
- Changes SoaEmail from dynamic `admin@{domain}` to static `hostmaster@bunny.net` in both `handleCreateZone` and `AddZone`
- Updates test assertions in handlers_test.go and server_test.go

Fixes #217

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi