### PR TITLE
fix(mockbunny): use real Bunny.net nameserver hostnames kiki/coco

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -271,8 +271,8 @@ func (s *Server) handleCreateZone(w http.ResponseWriter, r *http.Request) {
 		DateModified:             now,
 		NameserversDetected:      true,
 		CustomNameserversEnabled: false,
-		Nameserver1:              "ns1.bunny.net",
-		Nameserver2:              "ns2.bunny.net",
+		Nameserver1:              "kiki.bunny.net",
+		Nameserver2:              "coco.bunny.net",
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)

--- a/internal/testutil/mockbunny/handlers_test.go
+++ b/internal/testutil/mockbunny/handlers_test.go
@@ -552,11 +552,11 @@ func TestHandleCreateZone_Success(t *testing.T) {
 	if zone.ID == 0 {
 		t.Error("expected non-zero zone ID")
 	}
-	if zone.Nameserver1 != "ns1.bunny.net" {
-		t.Errorf("expected nameserver1 ns1.bunny.net, got %s", zone.Nameserver1)
+	if zone.Nameserver1 != "kiki.bunny.net" {
+		t.Errorf("expected nameserver1 kiki.bunny.net, got %s", zone.Nameserver1)
 	}
-	if zone.Nameserver2 != "ns2.bunny.net" {
-		t.Errorf("expected nameserver2 ns2.bunny.net, got %s", zone.Nameserver2)
+	if zone.Nameserver2 != "coco.bunny.net" {
+		t.Errorf("expected nameserver2 coco.bunny.net, got %s", zone.Nameserver2)
 	}
 	if zone.SoaEmail != "hostmaster@bunny.net" {
 		t.Errorf("expected SoaEmail hostmaster@bunny.net, got %s", zone.SoaEmail)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -132,8 +132,8 @@ func (s *Server) AddZone(domain string) int64 {
 		DateModified:             now,
 		NameserversDetected:      true,
 		CustomNameserversEnabled: false,
-		Nameserver1:              "ns1.bunny.net",
-		Nameserver2:              "ns2.bunny.net",
+		Nameserver1:              "kiki.bunny.net",
+		Nameserver2:              "coco.bunny.net",
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)

--- a/internal/testutil/mockbunny/server_test.go
+++ b/internal/testutil/mockbunny/server_test.go
@@ -165,11 +165,11 @@ func TestAddZone(t *testing.T) {
 	if zone.SoaEmail != "hostmaster@bunny.net" {
 		t.Errorf("expected hostmaster@bunny.net, got %s", zone.SoaEmail)
 	}
-	if zone.Nameserver1 != "ns1.bunny.net" {
-		t.Errorf("expected ns1.bunny.net, got %s", zone.Nameserver1)
+	if zone.Nameserver1 != "kiki.bunny.net" {
+		t.Errorf("expected kiki.bunny.net, got %s", zone.Nameserver1)
 	}
-	if zone.Nameserver2 != "ns2.bunny.net" {
-		t.Errorf("expected ns2.bunny.net, got %s", zone.Nameserver2)
+	if zone.Nameserver2 != "coco.bunny.net" {
+		t.Errorf("expected coco.bunny.net, got %s", zone.Nameserver2)
 	}
 	if !zone.NameserversDetected {
 		t.Error("expected NameserversDetected to be true")

--- a/internal/testutil/mockbunny/types_test.go
+++ b/internal/testutil/mockbunny/types_test.go
@@ -82,8 +82,8 @@ func TestZoneFields(t *testing.T) {
 		Records:                  []Record{},
 		NameserversDetected:      true,
 		CustomNameserversEnabled: false,
-		Nameserver1:              "ns1.bunny.net",
-		Nameserver2:              "ns2.bunny.net",
+		Nameserver1:              "kiki.bunny.net",
+		Nameserver2:              "coco.bunny.net",
 		SoaEmail:                 "admin@example.com",
 		LoggingEnabled:           false,
 		LoggingIPAnonymization:   true,
@@ -100,8 +100,8 @@ func TestZoneFields(t *testing.T) {
 		t.Errorf("Zone Domain = %s, want example.com", zone.Domain)
 	}
 
-	if zone.Nameserver1 != "ns1.bunny.net" {
-		t.Errorf("Nameserver1 = %s, want ns1.bunny.net", zone.Nameserver1)
+	if zone.Nameserver1 != "kiki.bunny.net" {
+		t.Errorf("Nameserver1 = %s, want kiki.bunny.net", zone.Nameserver1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changes nameserver values from generic `ns1.bunny.net`/`ns2.bunny.net` to actual `kiki.bunny.net`/`coco.bunny.net`
- Updates all test assertions across handlers_test.go, server_test.go, and types_test.go

Fixes #224

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi