### PR TITLE
fix(mockbunny): set NameserversNextCheck to future timestamp like real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -273,6 +273,7 @@ func (s *Server) handleCreateZone(w http.ResponseWriter, r *http.Request) {
 		CustomNameserversEnabled: false,
 		Nameserver1:              "kiki.bunny.net",
 		Nameserver2:              "coco.bunny.net",
+		NameserversNextCheck:     MockBunnyTime{Time: time.Now().Add(5 * time.Minute)},
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -134,6 +134,7 @@ func (s *Server) AddZone(domain string) int64 {
 		CustomNameserversEnabled: false,
 		Nameserver1:              "kiki.bunny.net",
 		Nameserver2:              "coco.bunny.net",
+		NameserversNextCheck:     MockBunnyTime{Time: time.Now().Add(5 * time.Minute)},
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)


### PR DESCRIPTION
## Summary
- Sets `NameserversNextCheck` to `time.Now() + 5 minutes` in both `handleCreateZone` and `AddZone`
- Previously omitted (zero value / null), now matches real API which returns ~5min future timestamp

Fixes #218

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi