### PR TITLE
fix(mockbunny): default LoggingIPAnonymizationEnabled to true like real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -275,6 +275,7 @@ func (s *Server) handleCreateZone(w http.ResponseWriter, r *http.Request) {
 		Nameserver2:              "coco.bunny.net",
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
+		LoggingIPAnonymization:   true,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)
 		DnsSecEnabled:            false,
 		CertificateKeyType:       0, // 0 = Ecdsa (default)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -136,6 +136,7 @@ func (s *Server) AddZone(domain string) int64 {
 		Nameserver2:              "coco.bunny.net",
 		SoaEmail:                 "hostmaster@bunny.net",
 		LoggingEnabled:           false,
+		LoggingIPAnonymization:   true,
 		LogAnonymizationType:     0, // 0 = OneDigit (default)
 		DnsSecEnabled:            false,
 		CertificateKeyType:       0, // 0 = Ecdsa (default)


### PR DESCRIPTION
## Summary
- Explicitly sets `LoggingIPAnonymization: true` in both `handleCreateZone` and `AddZone`
- Previously defaulted to Go zero value (`false`), real API defaults to `true`

Fixes #219

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi