### PR TITLE
fix(mockbunny): reorder ListZonesResponse fields to match real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -63,10 +63,10 @@ func (s *Server) handleListZones(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := ListZonesResponse{
+		Items:        zones,
 		CurrentPage:  page,
 		TotalItems:   total,
 		HasMoreItems: end < total,
-		Items:        zones,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/testutil/mockbunny/types.go
+++ b/internal/testutil/mockbunny/types.go
@@ -118,10 +118,10 @@ func NewState() *State {
 
 // ListZonesResponse is a paginated response for the List Zones endpoint.
 type ListZonesResponse struct {
+	Items        []Zone `json:"Items"`
 	CurrentPage  int    `json:"CurrentPage"`
 	TotalItems   int    `json:"TotalItems"`
 	HasMoreItems bool   `json:"HasMoreItems"`
-	Items        []Zone `json:"Items"`
 }
 
 // ErrorResponse represents an error response from the API.


### PR DESCRIPTION
## Summary
- Reorders `ListZonesResponse` struct to put `Items` first, matching real Bunny.net API JSON field order
- Updates struct literal in `handleListZones` to match

Fixes #226

## Test plan
- [x] `go test -race ./internal/testutil/mockbunny/...` passes
- [ ] CI green

https://claude.ai/code/session_01Bi3HGLPSdMH4cd6JKQfNSi