### PR TITLE
test: add input validation tests for proxy handler

### DIFF
--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1436,3 +1436,120 @@ func TestHandleListRecords_EmptyAfterFilter(t *testing.T) {
 		t.Errorf("expected 0 records after filtering, got %d", len(result))
 	}
 }
+
+// TestHandleListZones_InvalidPerPage tests handling of invalid perPage parameter
+func TestHandleListZones_InvalidPerPage(t *testing.T) {
+	t.Parallel()
+	client := &mockBunnyClient{}
+	handler := NewHandler(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/dnszone?perPage=invalid", nil)
+
+	handler.HandleListZones(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "invalid perPage parameter" {
+		t.Errorf("expected error message 'invalid perPage parameter', got %q", result["error"])
+	}
+}
+
+// TestHandleListRecords_MissingZoneID tests handling of missing zone ID parameter
+func TestHandleListRecords_MissingZoneID(t *testing.T) {
+	t.Parallel()
+	client := &mockBunnyClient{}
+	handler := NewHandler(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodGet, "/dnszone/records", nil, map[string]string{})
+
+	handler.HandleListRecords(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "missing zone ID" {
+		t.Errorf("expected error message 'missing zone ID', got %q", result["error"])
+	}
+}
+
+// TestHandleAddRecord_MissingZoneID tests handling of missing zone ID parameter
+func TestHandleAddRecord_MissingZoneID(t *testing.T) {
+	t.Parallel()
+	client := &mockBunnyClient{}
+	handler := NewHandler(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w := httptest.NewRecorder()
+
+	body := []byte(`{"Type":3,"Name":"test"}`)
+	r := newTestRequest(http.MethodPost, "/dnszone/records", bytes.NewReader(body), map[string]string{})
+
+	handler.HandleAddRecord(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "missing zone ID" {
+		t.Errorf("expected error message 'missing zone ID', got %q", result["error"])
+	}
+}
+
+// TestHandleDeleteRecord_MissingZoneID tests handling of missing zone ID parameter
+func TestHandleDeleteRecord_MissingZoneID(t *testing.T) {
+	t.Parallel()
+	client := &mockBunnyClient{}
+	handler := NewHandler(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodDelete, "/dnszone/records/456", nil, map[string]string{"recordID": "456"})
+
+	handler.HandleDeleteRecord(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "missing zone ID" {
+		t.Errorf("expected error message 'missing zone ID', got %q", result["error"])
+	}
+}
+
+// TestHandleDeleteRecord_MissingRecordID tests handling of missing record ID parameter
+func TestHandleDeleteRecord_MissingRecordID(t *testing.T) {
+	t.Parallel()
+	client := &mockBunnyClient{}
+	handler := NewHandler(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodDelete, "/dnszone/123/records", nil, map[string]string{"zoneID": "123"})
+
+	handler.HandleDeleteRecord(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result["error"] != "missing record ID" {
+		t.Errorf("expected error message 'missing record ID', got %q", result["error"])
+	}
+}


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for input validation error paths in `internal/proxy/handler.go`, improving coverage from 93.2% to 99.4%.

## Changes

Added 5 new test cases to cover previously untested validation error conditions:

1. **TestHandleListZones_InvalidPerPage** - Invalid non-numeric `perPage` query parameter
2. **TestHandleListRecords_MissingZoneID** - Missing `zoneID` URL parameter
3. **TestHandleAddRecord_MissingZoneID** - Missing `zoneID` URL parameter  
4. **TestHandleDeleteRecord_MissingZoneID** - Missing `zoneID` URL parameter
5. **TestHandleDeleteRecord_MissingRecordID** - Missing `recordID` URL parameter

All tests verify correct HTTP status codes (400 Bad Request) and proper error message format.

## Test Results

- All tests pass ✓
- Coverage: proxy package now at 99.4% (up from 93.2%)
- Lint: 0 issues
- CI: All checks green

## Acceptance Criteria

- [x] All 11 uncovered lines in handler.go now have test coverage
- [x] Tests verify correct HTTP status codes (400 for bad input)
- [x] Tests verify error messages are sensible
- [x] \`make lint tidy test\` passes locally
- [x] Coverage check passes: internal/proxy at 99.4%
- [x] No linter errors: golangci-lint run (0 issues)
- [x] CI passes after push
- [x] PR checks are all green

https://claude.ai/code/session_01EQMrv73PazgutSj5RvwdYk