### PR TITLE
feat(mockbunny): add 6 missing record-level fields from real API

### DIFF
--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -267,21 +267,27 @@ func (s *Server) handleAddRecord(w http.ResponseWriter, r *http.Request) {
 
 	// Create record with defaults
 	record := Record{
-		ID:               s.state.nextRecordID,
-		Type:             req.Type,
-		Name:             req.Name,
-		Value:            req.Value,
-		TTL:              req.TTL,
-		Priority:         req.Priority,
-		Weight:           req.Weight,
-		Port:             req.Port,
-		Flags:            req.Flags,
-		Tag:              req.Tag,
-		Disabled:         req.Disabled,
-		Comment:          req.Comment,
-		MonitorStatus:    0, // 0 = Unknown
-		MonitorType:      0, // 0 = None
-		SmartRoutingType: 0, // 0 = None
+		ID:                    s.state.nextRecordID,
+		Type:                  req.Type,
+		Name:                  req.Name,
+		Value:                 req.Value,
+		TTL:                   req.TTL,
+		Priority:              req.Priority,
+		Weight:                req.Weight,
+		Port:                  req.Port,
+		Flags:                 req.Flags,
+		Tag:                   req.Tag,
+		Disabled:              req.Disabled,
+		Comment:               req.Comment,
+		LinkName:              "",
+		IPGeoLocationInfo:     nil,
+		GeolocationInfo:       nil,
+		MonitorStatus:         0, // 0 = Unknown
+		MonitorType:           0, // 0 = None
+		EnviromentalVariables: []interface{}{},
+		SmartRoutingType:      0, // 0 = None
+		AutoSslIssuance:       true,
+		AccelerationStatus:    0,
 	}
 	s.state.nextRecordID++
 

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -160,10 +160,12 @@ func (s *Server) AddZoneWithRecords(domain string, records []Record) int64 {
 	for i := range records {
 		records[i].ID = s.state.nextRecordID
 		s.state.nextRecordID++
-		// Set defaults for unset fields (0 values)
-		// MonitorStatus defaults to 0 (Unknown)
-		// MonitorType defaults to 0 (None)
-		// SmartRoutingType defaults to 0 (None)
+		// Set defaults for new fields added to match real API behavior
+		if records[i].EnviromentalVariables == nil {
+			records[i].EnviromentalVariables = []interface{}{}
+		}
+		// AutoSslIssuance always defaults to true in real API
+		records[i].AutoSslIssuance = true
 	}
 	zone.Records = records
 	zone.DateModified = MockBunnyTime{Time: time.Now().UTC()}

--- a/internal/testutil/mockbunny/types.go
+++ b/internal/testutil/mockbunny/types.go
@@ -55,26 +55,32 @@ func (t *MockBunnyTime) UnmarshalJSON(b []byte) error {
 
 // Record represents a DNS record within a zone.
 type Record struct {
-	ID                    int64   `json:"Id"`
-	Type                  int     `json:"Type"` // 0 = A, 1 = AAAA, 2 = CNAME, 3 = TXT, 4 = MX, 5 = SPF, 6 = Flatten, 7 = PullZone, 8 = SRV, 9 = CAA, 10 = PTR, 11 = Script, 12 = NS
-	Name                  string  `json:"Name"`
-	Value                 string  `json:"Value"`
-	TTL                   int32   `json:"Ttl"`
-	Priority              int32   `json:"Priority"`
-	Weight                int32   `json:"Weight"`
-	Port                  int32   `json:"Port"`
-	Flags                 int     `json:"Flags"`
-	Tag                   string  `json:"Tag"`
-	Accelerated           bool    `json:"Accelerated"`
-	AcceleratedPullZoneID int64   `json:"AcceleratedPullZoneId"`
-	MonitorStatus         int     `json:"MonitorStatus"` // 0 = Unknown, 1 = Online, 2 = Offline
-	MonitorType           int     `json:"MonitorType"`   // 0 = None, 1 = Ping, 2 = Http, 3 = Monitor
-	GeolocationLatitude   float64 `json:"GeolocationLatitude"`
-	GeolocationLongitude  float64 `json:"GeolocationLongitude"`
-	LatencyZone           *string `json:"LatencyZone"`
-	SmartRoutingType      int     `json:"SmartRoutingType"` // 0 = None, 1 = Latency, 2 = Geolocation
-	Disabled              bool    `json:"Disabled"`
-	Comment               string  `json:"Comment"`
+	ID                    int64         `json:"Id"`
+	Type                  int           `json:"Type"` // 0 = A, 1 = AAAA, 2 = CNAME, 3 = TXT, 4 = MX, 5 = SPF, 6 = Flatten, 7 = PullZone, 8 = SRV, 9 = CAA, 10 = PTR, 11 = Script, 12 = NS
+	Name                  string        `json:"Name"`
+	Value                 string        `json:"Value"`
+	TTL                   int32         `json:"Ttl"`
+	Priority              int32         `json:"Priority"`
+	Weight                int32         `json:"Weight"`
+	Port                  int32         `json:"Port"`
+	Flags                 int           `json:"Flags"`
+	Tag                   string        `json:"Tag"`
+	Accelerated           bool          `json:"Accelerated"`
+	AcceleratedPullZoneID int64         `json:"AcceleratedPullZoneId"`
+	LinkName              string        `json:"LinkName"`
+	IPGeoLocationInfo     interface{}   `json:"IPGeoLocationInfo"`
+	GeolocationInfo       interface{}   `json:"GeolocationInfo"`
+	MonitorStatus         int           `json:"MonitorStatus"` // 0 = Unknown, 1 = Online, 2 = Offline
+	MonitorType           int           `json:"MonitorType"`   // 0 = None, 1 = Ping, 2 = Http, 3 = Monitor
+	GeolocationLatitude   float64       `json:"GeolocationLatitude"`
+	GeolocationLongitude  float64       `json:"GeolocationLongitude"`
+	EnviromentalVariables []interface{} `json:"EnviromentalVariables"`
+	LatencyZone           *string       `json:"LatencyZone"`
+	SmartRoutingType      int           `json:"SmartRoutingType"` // 0 = None, 1 = Latency, 2 = Geolocation
+	Disabled              bool          `json:"Disabled"`
+	Comment               string        `json:"Comment"`
+	AutoSslIssuance       bool          `json:"AutoSslIssuance"`
+	AccelerationStatus    int           `json:"AccelerationStatus"`
 }
 
 // Zone represents a DNS zone.

--- a/internal/testutil/mockbunny/types_test.go
+++ b/internal/testutil/mockbunny/types_test.go
@@ -51,14 +51,20 @@ func TestRecordFields(t *testing.T) {
 		Tag:                   "test",
 		Accelerated:           false,
 		AcceleratedPullZoneID: 0,
+		LinkName:              "",
+		IPGeoLocationInfo:     nil,
+		GeolocationInfo:       nil,
 		MonitorStatus:         1, // Online
 		MonitorType:           2, // Http
 		GeolocationLatitude:   0.0,
 		GeolocationLongitude:  0.0,
+		EnviromentalVariables: []interface{}{},
 		LatencyZone:           nil,
 		SmartRoutingType:      1, // Latency
 		Disabled:              false,
 		Comment:               "test record",
+		AutoSslIssuance:       true,
+		AccelerationStatus:    0,
 	}
 
 	if record.ID != 1 {


### PR DESCRIPTION
Add 6 missing record-level fields to mockbunny to match the real bunny.net API

Changes:
- LinkName (string)
- IPGeoLocationInfo (null)
- GeolocationInfo (null)
- EnviromentalVariables (array)
- AutoSslIssuance (bool, defaults to true)
- AccelerationStatus (int)

All tests pass (CI run #736: PASSED)
Fixes #254