### PR TITLE
Enforce code formatting with auto-fixing git hooks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,10 +37,14 @@ Write tests first, then implementation. Tests are the safety net.
 - Prefer simplicity over cleverness
 
 ### Git workflow
+- **ALWAYS** run `make fmt` before committing (auto-formats all Go code)
+- Run `make pre-commit-check` before pushing to catch all issues
 - Commit messages should be clear and descriptive
 - Never commit secrets or API keys
+- Never use `--no-verify` to skip git hooks
 - CI validates all changes via GitHub Actions
-- Pre-commit hooks enforce formatting and linting locally
+- Pre-commit hooks auto-format code and enforce linting
+- Pre-push hooks run final tests and validation
 
 ### Development Setup
 
@@ -50,17 +54,53 @@ Run once after cloning to install Git pre-commit hooks:
 make setup
 ```
 
-This installs [lefthook](https://github.com/evilmartians/lefthook) hooks that automatically run `gofmt`, `golangci-lint`, and `go mod tidy` checks before each commit.
+This installs [lefthook](https://github.com/evilmartians/lefthook) hooks that automatically:
+- Format Go code with `gofmt` before each commit
+- Run `golangci-lint` on staged files
+- Validate `go.mod` and `go.sum` are tidy
+- Run full tests and linting before push
+
+### Code Formatting (CRITICAL FOR AI AGENTS)
+
+**ALWAYS format code before committing.** Git hooks will auto-format, but agents should be explicit:
+
+```bash
+# Format all Go code (run BEFORE staging/committing)
+make fmt
+
+# Check if code is formatted without changing files
+make fmt-check
+
+# Run ALL pre-commit checks (format + lint + tidy + test)
+make pre-commit-check
+```
+
+**Workflow for AI agents:**
+1. Write/modify code
+2. Run `make fmt` to format
+3. Run `make pre-commit-check` to validate
+4. Stage files with `git add`
+5. Commit (hooks will run automatically)
+6. Push (pre-push hooks will validate again)
+
+**NEVER skip formatting.** Unformatted code will be rejected by CI.
 
 ### Local Validation
 
 Run before pushing to catch issues early:
 
 ```bash
-make lint tidy test
+# Full validation (recommended before push)
+make pre-commit-check
+
+# Individual checks
+make fmt-check    # Check formatting only
+make lint         # Run golangci-lint
+make tidy         # Check go.mod/go.sum
+make test         # Run tests with coverage
 ```
 
-Pre-commit hooks catch formatting issues automatically, but run full validation before pushing.
+Pre-commit hooks will auto-format and validate, but pre-push hooks provide final safety checks.
 
 ### GitHub CLI
 

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -3,18 +3,41 @@
 # https://github.com/evilmartians/lefthook
 
 pre-commit:
-  parallel: true
+  parallel: false
   commands:
-    gofmt:
+    # Auto-format Go code before commit
+    gofmt-fix:
       glob: "*.go"
-      run: gofmt -l -d {staged_files} && test -z "$(gofmt -l {staged_files})"
-      fail_text: "gofmt found unformatted files - run 'gofmt -w .' to fix"
+      run: gofmt -w {staged_files} && git add {staged_files}
+      stage_fixed: true
 
+    # Run linter on staged files
     golangci-lint:
       glob: "*.go"
       run: golangci-lint run --new-from-rev=HEAD~1 {staged_files}
-      fail_text: "golangci-lint found issues"
+      fail_text: "golangci-lint found issues - fix them before committing"
 
+    # Ensure go.mod and go.sum are tidy
     go-mod-tidy:
       run: go mod tidy && git diff --exit-code go.mod go.sum
-      fail_text: "go.mod/go.sum not tidy - run 'go mod tidy'"
+      fail_text: "go.mod/go.sum not tidy - run 'go mod tidy' and stage the changes"
+
+# Pre-push hook as extra safety check
+pre-push:
+  parallel: true
+  commands:
+    # Final format check before push
+    gofmt-final:
+      glob: "*.go"
+      run: test -z "$(gofmt -l .)"
+      fail_text: "Unformatted code detected before push - run 'make fmt' to fix"
+
+    # Run full linter before push
+    golangci-lint-full:
+      run: golangci-lint run
+      fail_text: "Linter issues detected - fix before pushing"
+
+    # Ensure tests pass before push
+    tests:
+      run: go test -race ./...
+      fail_text: "Tests failed - fix before pushing"


### PR DESCRIPTION
## Summary

Fixes the issue where AI agents and developers were forgetting to format code before committing/pushing. The git hooks now automatically format code and provide comprehensive validation at both commit and push time.

## Changes

### Makefile
- Fixed `install-hooks` to properly install lefthook via `go install`
- Added `make fmt` - auto-formats all Go code
- Added `make fmt-check` - verifies formatting without changes
- Added `make pre-commit-check` - comprehensive validation (format + lint + tidy + test)

### .lefthook.yml
- **Pre-commit hook** now auto-formats staged files with `gofmt -w` and re-stages them
- Added **pre-push hook** that validates formatting, runs full linter, and runs all tests
- Prevents unformatted or broken code from being pushed

### CLAUDE.md
- Added prominent "Code Formatting (CRITICAL FOR AI AGENTS)" section
- Clear workflow instructions for agents
- Emphasized never skip formatting or use `--no-verify`

## How It Works

1. **Pre-commit**: Automatically formats code when you commit
2. **Pre-push**: Validates everything before allowing push (format check, full lint, all tests)
3. **Safety**: No way to accidentally commit/push unformatted code

## Test Plan

- [x] Tested pre-commit hook auto-formats unformatted code
- [x] Tested pre-push hook runs all validations
- [x] Successfully committed and pushed these changes using the new hooks
- [x] All hooks passed (formatting ✅, linting ✅, tests ✅)

https://claude.ai/code/session_018eMc4DXdcEpbzgqhWKPwEt