### PR TITLE
feat(proxy): add Check DNS Zone Availability endpoint (admin only)

### DIFF
--- a/internal/auth/actions.go
+++ b/internal/auth/actions.go
@@ -13,12 +13,13 @@ import (
 
 // URL patterns for DNS API endpoints (matching bunny.net API paths)
 var (
-	listZonesPattern    = regexp.MustCompile(`^/dnszone/?$`)
-	getZonePattern      = regexp.MustCompile(`^/dnszone/(\d+)/?$`)
-	updateZonePattern   = regexp.MustCompile(`^/dnszone/(\d+)/?$`)
-	recordsPattern      = regexp.MustCompile(`^/dnszone/(\d+)/records/?$`)
-	updateRecordPattern = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
-	deleteRecordPattern = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
+	listZonesPattern         = regexp.MustCompile(`^/dnszone/?$`)
+	getZonePattern           = regexp.MustCompile(`^/dnszone/(\d+)/?$`)
+	updateZonePattern        = regexp.MustCompile(`^/dnszone/(\d+)/?$`)
+	recordsPattern           = regexp.MustCompile(`^/dnszone/(\d+)/records/?$`)
+	updateRecordPattern      = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
+	deleteRecordPattern      = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
+	checkAvailabilityPattern = regexp.MustCompile(`^/dnszone/checkavailability/?$`)
 )
 
 // ParseRequest extracts action, zone ID, and record type from HTTP request.
@@ -45,6 +46,10 @@ func ParseRequest(r *http.Request) (*Request, error) {
 		return &Request{Action: ActionListRecords, ZoneID: zoneID}, nil
 	}
 
+	// POST /dnszone/checkavailability - check zone availability (admin only)
+	if r.Method == http.MethodPost && checkAvailabilityPattern.MatchString(path) {
+		return &Request{Action: ActionCheckAvailability}, nil
+	}
 	// POST /dnszone - create zone
 	if r.Method == http.MethodPost && listZonesPattern.MatchString(path) {
 		return &Request{Action: ActionCreateZone}, nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -36,6 +36,8 @@ const (
 	ActionCreateZone Action = "create_zone"
 	// ActionUpdateZone updates zone-level settings (admin only).
 	ActionUpdateZone Action = "update_zone"
+	// ActionCheckAvailability checks DNS zone availability (admin only).
+	ActionCheckAvailability Action = "check_availability"
 )
 
 // Errors for authentication and authorization failures.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -154,7 +154,7 @@ func (m *Authenticator) CheckPermissions(next http.Handler) http.Handler {
 		}
 
 		// Check if this is an admin-only action
-		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone {
+		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability {
 			writeJSONErrorWithCode(w, http.StatusForbidden, "admin_required", "This endpoint requires an admin token.")
 			return
 		}

--- a/internal/bunny/types.go
+++ b/internal/bunny/types.go
@@ -114,3 +114,13 @@ type UpdateZoneRequest struct {
 	CertificateKeyType            *int    `json:"CertificateKeyType,omitempty"`
 	LoggingIPAnonymizationEnabled *bool   `json:"LoggingIPAnonymizationEnabled,omitempty"`
 }
+
+// CheckAvailabilityRequest represents the request body for checking zone availability.
+type CheckAvailabilityRequest struct {
+	Name string `json:"Name"`
+}
+
+// CheckAvailabilityResponse represents the response from the check availability endpoint.
+type CheckAvailabilityResponse struct {
+	Available bool `json:"Available"`
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -24,6 +24,7 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	// Wire handler methods to routes
 	r.Get("/dnszone", handler.HandleListZones)
 	r.Post("/dnszone", handler.HandleCreateZone)
+	r.With(requireAdmin).Post("/dnszone/checkavailability", handler.HandleCheckAvailability)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}", handler.HandleUpdateZone)
 	r.Get("/dnszone/{zoneID}", handler.HandleGetZone)
 	r.Delete("/dnszone/{zoneID}", handler.HandleDeleteZone)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -69,6 +69,7 @@ func New() *Server {
 		}
 		r.Get("/dnszone", server.handleListZones)
 		r.Post("/dnszone", server.handleCreateZone)
+		r.Post("/dnszone/checkavailability", server.handleCheckAvailability)
 		r.Get("/dnszone/{id}", server.handleGetZone)
 		r.Delete("/dnszone/{id}", server.handleDeleteZone)
 		r.Post("/dnszone/{id}", server.handleUpdateZone)


### PR DESCRIPTION
## Summary
- Add `POST /dnszone/checkavailability` endpoint to check if a domain name is available to be added as a DNS zone
- Admin-only endpoint (zone-less operation for zone creation workflows)
- Route registered before `{zoneID}` wildcard to avoid routing conflicts

## Changes
- Add `CheckZoneAvailability` to `BunnyClient` interface and bunny client
- Add `HandleCheckAvailability` proxy handler with input validation
- Add `ActionCheckAvailability` auth action (admin-only, blocked for scoped tokens)
- Add mockbunny handler (checks domain existence in mock state)
- Add comprehensive tests: 5 handler unit tests, 2 integration tests, 6 client tests

## Test plan
- [x] Handler tests: success, not available, invalid body, missing name, client error
- [x] Integration tests: admin-only auth (admin/non-admin/invalid token), existing zone check
- [x] Client tests: available, unavailable, 401, 400, context cancellation, malformed JSON
- [x] `make fmt` / `make lint` / `make test` all pass locally
- [x] Coverage: proxy 98.0%, bunny 87.2% (above 85% threshold)

Closes #237

https://claude.ai/code/session_011ZL4TYWQuErtkvnePpHsw8