### PR TITLE
feat(proxy): add Import DNS Records endpoint (admin only)

### DIFF
--- a/internal/auth/actions.go
+++ b/internal/auth/actions.go
@@ -20,6 +20,7 @@ var (
 	updateRecordPattern      = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
 	deleteRecordPattern      = regexp.MustCompile(`^/dnszone/(\d+)/records/(\d+)/?$`)
 	checkAvailabilityPattern = regexp.MustCompile(`^/dnszone/checkavailability/?$`)
+	importRecordsPattern     = regexp.MustCompile(`^/dnszone/(\d+)/import/?$`)
 )
 
 // ParseRequest extracts action, zone ID, and record type from HTTP request.
@@ -45,8 +46,14 @@ func ParseRequest(r *http.Request) (*Request, error) {
 		zoneID, _ := strconv.ParseInt(matches[1], 10, 64) //nolint:errcheck // regex ensures valid number
 		return &Request{Action: ActionListRecords, ZoneID: zoneID}, nil
 	}
-
 	// POST /dnszone/checkavailability - check zone availability (admin only)
+	// POST /dnszone/{id}/import - import records (admin only)
+	if r.Method == http.MethodPost {
+		if matches := importRecordsPattern.FindStringSubmatch(path); matches != nil {
+			zoneID, _ := strconv.ParseInt(matches[1], 10, 64) //nolint:errcheck // regex ensures valid number
+			return &Request{Action: ActionImportRecords, ZoneID: zoneID}, nil
+		}
+	}
 	if r.Method == http.MethodPost && checkAvailabilityPattern.MatchString(path) {
 		return &Request{Action: ActionCheckAvailability}, nil
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -38,6 +38,8 @@ const (
 	ActionUpdateZone Action = "update_zone"
 	// ActionCheckAvailability checks DNS zone availability (admin only).
 	ActionCheckAvailability Action = "check_availability"
+	// ActionImportRecords imports DNS records (admin only).
+	ActionImportRecords Action = "import_records"
 )
 
 // Errors for authentication and authorization failures.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -154,7 +154,7 @@ func (m *Authenticator) CheckPermissions(next http.Handler) http.Handler {
 		}
 
 		// Check if this is an admin-only action
-		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability {
+		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords {
 			writeJSONErrorWithCode(w, http.StatusForbidden, "admin_required", "This endpoint requires an admin token.")
 			return
 		}

--- a/internal/bunny/client_test.go
+++ b/internal/bunny/client_test.go
@@ -1502,3 +1502,147 @@ func TestCheckZoneAvailability(t *testing.T) {
 		}
 	})
 }
+
+// TestImportRecords tests the ImportRecords method with various scenarios.
+func TestImportRecords(t *testing.T) {
+	t.Parallel()
+	t.Run("success importing records", func(t *testing.T) {
+		t.Parallel()
+		server := mockbunny.New()
+		defer server.Close()
+
+		zoneID := server.AddZone("example.com")
+
+		client := NewClient("test-key", WithBaseURL(server.URL()))
+		body := strings.NewReader("example.com. 300 IN A 1.2.3.4\nexample.com. 300 IN TXT \"test\"")
+		result, err := client.ImportRecords(context.Background(), zoneID, body, "text/plain")
+
+		if err != nil {
+			t.Fatalf("ImportRecords failed: %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+
+		if result.RecordsSuccessful != 2 {
+			t.Errorf("expected 2 successful records, got %d", result.RecordsSuccessful)
+		}
+	})
+
+	t.Run("zone not found (404)", func(t *testing.T) {
+		t.Parallel()
+		server := mockbunny.New()
+		defer server.Close()
+
+		client := NewClient("test-key", WithBaseURL(server.URL()))
+		body := strings.NewReader("example.com. 300 IN A 1.2.3.4")
+		result, err := client.ImportRecords(context.Background(), 999, body, "text/plain")
+
+		if err != ErrNotFound {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("unauthorized error (401)", func(t *testing.T) {
+		t.Parallel()
+		transport := &mockTransport{
+			statusCode: http.StatusUnauthorized,
+			body:       []byte(""),
+		}
+		httpClient := &http.Client{Transport: transport}
+
+		client := NewClient("test-key", WithHTTPClient(httpClient))
+		body := strings.NewReader("example.com. 300 IN A 1.2.3.4")
+		result, err := client.ImportRecords(context.Background(), 1, body, "text/plain")
+
+		if err != ErrUnauthorized {
+			t.Errorf("expected ErrUnauthorized, got %v", err)
+		}
+
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("bad request error (400)", func(t *testing.T) {
+		t.Parallel()
+		transport := &mockTransport{
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"ErrorKey":"BadRequest","Message":"Invalid zone file format"}`),
+		}
+		httpClient := &http.Client{Transport: transport}
+
+		client := NewClient("test-key", WithHTTPClient(httpClient))
+		body := strings.NewReader("invalid data")
+		result, err := client.ImportRecords(context.Background(), 1, body, "text/plain")
+
+		if err == nil {
+			t.Fatal("expected error for 400 response")
+		}
+
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		apiErr, ok := err.(*APIError)
+		if !ok {
+			t.Fatalf("expected *APIError, got %T", err)
+		}
+
+		if apiErr.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected status 400, got %d", apiErr.StatusCode)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		t.Parallel()
+		server := mockbunny.New()
+		defer server.Close()
+
+		server.AddZone("example.com")
+		client := NewClient("test-key", WithBaseURL(server.URL()))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		body := strings.NewReader("example.com. 300 IN A 1.2.3.4")
+		result, err := client.ImportRecords(ctx, 1, body, "text/plain")
+
+		if err == nil {
+			t.Error("expected error with cancelled context")
+		}
+		if result != nil {
+			t.Error("expected nil result on error")
+		}
+	})
+
+	t.Run("malformed response body", func(t *testing.T) {
+		t.Parallel()
+		transport := &mockTransport{
+			statusCode: http.StatusOK,
+			body:       []byte("not valid json"),
+		}
+		httpClient := &http.Client{Transport: transport}
+
+		client := NewClient("test-key", WithHTTPClient(httpClient))
+		body := strings.NewReader("example.com. 300 IN A 1.2.3.4")
+		result, err := client.ImportRecords(context.Background(), 1, body, "text/plain")
+
+		if err == nil {
+			t.Fatal("expected error for malformed JSON")
+		}
+
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		if !strings.Contains(err.Error(), "parse") {
+			t.Errorf("expected parse error message, got %v", err)
+		}
+	})
+}

--- a/internal/bunny/types.go
+++ b/internal/bunny/types.go
@@ -124,3 +124,10 @@ type CheckAvailabilityRequest struct {
 type CheckAvailabilityResponse struct {
 	Available bool `json:"Available"`
 }
+
+// ImportRecordsResponse represents the response from the import DNS records endpoint.
+type ImportRecordsResponse struct {
+	RecordsSuccessful int `json:"RecordsSuccessful"`
+	RecordsFailed     int `json:"RecordsFailed"`
+	RecordsSkipped    int `json:"RecordsSkipped"`
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -25,6 +25,7 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	r.Get("/dnszone", handler.HandleListZones)
 	r.Post("/dnszone", handler.HandleCreateZone)
 	r.With(requireAdmin).Post("/dnszone/checkavailability", handler.HandleCheckAvailability)
+	r.With(requireAdmin).Post("/dnszone/{zoneID}/import", handler.HandleImportRecords)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}", handler.HandleUpdateZone)
 	r.Get("/dnszone/{zoneID}", handler.HandleGetZone)
 	r.Delete("/dnszone/{zoneID}", handler.HandleDeleteZone)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -72,6 +72,7 @@ func New() *Server {
 		r.Post("/dnszone/checkavailability", server.handleCheckAvailability)
 		r.Get("/dnszone/{id}", server.handleGetZone)
 		r.Delete("/dnszone/{id}", server.handleDeleteZone)
+		r.Post("/dnszone/{id}/import", server.handleImportRecords)
 		r.Post("/dnszone/{id}", server.handleUpdateZone)
 		r.Put("/dnszone/{zoneId}/records", server.handleAddRecord)
 		r.Post("/dnszone/{zoneId}/records/{id}", server.handleUpdateRecord)


### PR DESCRIPTION
## Summary
- Add `POST /dnszone/{id}/import` endpoint to import DNS records from BIND zone file format
- Admin-only endpoint — bulk import operation
- Forwards raw request body as-is to bunny.net (not JSON-encoded)

## Changes
- Add `ImportRecords` to `BunnyClient` interface and bunny client (raw body + content-type forwarding)
- Add `HandleImportRecords` proxy handler with zone ID validation
- Add `ActionImportRecords` auth action (admin-only, blocked for scoped tokens)
- Add mockbunny handler (simulates import by counting non-comment lines)
- Add comprehensive tests: 4 handler unit tests, 1 integration test (admin/non-admin/invalid), 6 client tests

## Test plan
- [x] Handler tests: success, invalid zone ID, not found, client error
- [x] Integration test: admin-only auth (admin/non-admin/invalid token)
- [x] Client tests: success, 404, 401, 400, context cancellation, malformed JSON
- [x] `make fmt` / `make lint` / `make test` all pass locally
- [x] Coverage: proxy 97.3%, bunny 87.5%, mockbunny 87.7% (all above 85%)

Closes #238

https://claude.ai/code/session_011ZL4TYWQuErtkvnePpHsw8