### PR TITLE
feat: add Issue Wildcard Certificate endpoint (admin only)

### DIFF
--- a/internal/auth/actions.go
+++ b/internal/auth/actions.go
@@ -23,6 +23,7 @@ var (
 	importRecordsPattern     = regexp.MustCompile(`^/dnszone/(\d+)/import/?$`)
 	exportRecordsPattern     = regexp.MustCompile(`^/dnszone/(\d+)/export/?$`)
 	dnssecPattern            = regexp.MustCompile(`^/dnszone/(\d+)/dnssec/?$`)
+	issueCertificatePattern  = regexp.MustCompile(`^/dnszone/(\d+)/certificate/issue/?$`)
 )
 
 // ParseRequest extracts action, zone ID, and record type from HTTP request.
@@ -79,6 +80,14 @@ func ParseRequest(r *http.Request) (*Request, error) {
 			return &Request{Action: ActionDisableDNSSEC, ZoneID: zoneID}, nil
 		}
 	}
+	// POST /dnszone/{id}/certificate/issue - issue wildcard certificate (admin only)
+	if r.Method == http.MethodPost {
+		if matches := issueCertificatePattern.FindStringSubmatch(path); matches != nil {
+			zoneID, _ := strconv.ParseInt(matches[1], 10, 64) //nolint:errcheck // regex ensures valid number
+			return &Request{Action: ActionIssueCertificate, ZoneID: zoneID}, nil
+		}
+	}
+
 	// POST /dnszone/{id} - update zone (admin only, no permission checking needed)
 	if r.Method == http.MethodPost {
 		if matches := updateZonePattern.FindStringSubmatch(path); matches != nil {

--- a/internal/auth/actions_test.go
+++ b/internal/auth/actions_test.go
@@ -129,6 +129,14 @@ func TestParseRequest(t *testing.T) {
 			wantZoneID: 123,
 		},
 		{
+			name:       "issue certificate",
+			method:     "POST",
+			path:       "/dnszone/123/certificate/issue",
+			body:       `{"Domain":"*.example.com"}`,
+			wantAction: ActionIssueCertificate,
+			wantZoneID: 123,
+		},
+		{
 			name:    "invalid path",
 			method:  "GET",
 			path:    "/invalid",

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -46,6 +46,8 @@ const (
 	ActionEnableDNSSEC Action = "enable_dnssec"
 	// ActionDisableDNSSEC disables DNSSEC for a zone (admin only).
 	ActionDisableDNSSEC Action = "disable_dnssec"
+	// ActionIssueCertificate issues a wildcard SSL certificate (admin only).
+	ActionIssueCertificate Action = "issue_certificate"
 )
 
 // Errors for authentication and authorization failures.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -153,7 +153,7 @@ func (m *Authenticator) CheckPermissions(next http.Handler) http.Handler {
 			return
 		}
 
-		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords {
+		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords || req.Action == ActionEnableDNSSEC || req.Action == ActionDisableDNSSEC || req.Action == ActionIssueCertificate {
 			writeJSONErrorWithCode(w, http.StatusForbidden, "admin_required", "This endpoint requires an admin token.")
 			return
 		}

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1330,3 +1330,58 @@ func TestIntegration_DisableDNSSEC_AdminOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_IssueCertificate_AdminOnly(t *testing.T) {
+	t.Parallel()
+	mockServer := mockbunny.New()
+	defer mockServer.Close()
+
+	zoneID := mockServer.AddZone("example.com")
+
+	db, err := storage.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+
+	_, err = db.CreateAdminToken(context.Background(), "admin-cert", "admin-cert-issue-token")
+	if err != nil {
+		t.Fatalf("failed to create admin token: %v", err)
+	}
+
+	scopedToken := "scoped-cert-issue-token"
+	scopedHash := sha256.Sum256([]byte(scopedToken))
+	_, err = db.CreateToken(context.Background(), "scoped-cert", false, hex.EncodeToString(scopedHash[:]))
+	if err != nil {
+		t.Fatalf("failed to create scoped token: %v", err)
+	}
+
+	client := bunny.NewClient("test-key", bunny.WithBaseURL(mockServer.URL()))
+	handler := NewHandler(client, testLogger())
+	bootstrapService := auth.NewBootstrapService(db, "master-key")
+	authenticator := auth.NewAuthenticator(db, bootstrapService)
+	router := NewRouter(handler, authenticator.Authenticate, testLogger())
+
+	tests := []struct {
+		name       string
+		token      string
+		wantStatus int
+	}{
+		{"admin token succeeds", "admin-cert-issue-token", http.StatusOK},
+		{"scoped token gets 403", scopedToken, http.StatusForbidden},
+		{"invalid token gets 401", "invalid-token", http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"Domain":"*.example.com"}`
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/dnszone/%d/certificate/issue", zoneID), bytes.NewBufferString(body))
+			req.Header.Set("AccessKey", tt.token)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d (body: %s)", tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -29,6 +29,7 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	r.With(requireAdmin).Get("/dnszone/{zoneID}/export", handler.HandleExportRecords)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}/dnssec", handler.HandleEnableDNSSEC)
 	r.With(requireAdmin).Delete("/dnszone/{zoneID}/dnssec", handler.HandleDisableDNSSEC)
+	r.With(requireAdmin).Post("/dnszone/{zoneID}/certificate/issue", handler.HandleIssueCertificate)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}", handler.HandleUpdateZone)
 	r.Get("/dnszone/{zoneID}", handler.HandleGetZone)
 	r.Delete("/dnszone/{zoneID}", handler.HandleDeleteZone)

--- a/internal/testutil/mockbunny/handlers.go
+++ b/internal/testutil/mockbunny/handlers.go
@@ -664,6 +664,31 @@ func (s *Server) handleDisableDNSSEC(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleIssueCertificate handles POST /dnszone/{id}/certificate/issue.
+func (s *Server) handleIssueCertificate(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "invalid zone ID", http.StatusBadRequest)
+		return
+	}
+
+	s.state.mu.RLock()
+	_, ok := s.state.zones[id]
+	s.state.mu.RUnlock()
+
+	if !ok {
+		s.writeError(w, http.StatusNotFound, "dnszone.zone.not_found", "Id", "The requested DNS zone was not found")
+		return
+	}
+
+	// Read and discard body
+	//nolint:errcheck
+	io.ReadAll(r.Body)
+
+	w.WriteHeader(http.StatusOK)
+}
+
 // recordTypeName converts a record type integer to its DNS name.
 func recordTypeName(t int) string {
 	switch t {

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -76,6 +76,7 @@ func New() *Server {
 		r.Get("/dnszone/{id}/export", server.handleExportRecords)
 		r.Post("/dnszone/{id}/dnssec", server.handleEnableDNSSEC)
 		r.Delete("/dnszone/{id}/dnssec", server.handleDisableDNSSEC)
+		r.Post("/dnszone/{id}/certificate/issue", server.handleIssueCertificate)
 		r.Post("/dnszone/{id}", server.handleUpdateZone)
 		r.Put("/dnszone/{zoneId}/records", server.handleAddRecord)
 		r.Post("/dnszone/{zoneId}/records/{id}", server.handleUpdateRecord)


### PR DESCRIPTION
## Summary
- Add `POST /dnszone/{zoneID}/certificate/issue` endpoint to trigger wildcard SSL certificate issuance
- Admin-only access (defense-in-depth: `requireAdmin` router middleware + `CheckPermissions` auth middleware)
- Accepts JSON body with optional `Domain` field
- Also fixes missing DNSSEC actions in `CheckPermissions` admin-only check from PR #282

Closes #242

## Changes
- Add `IssueCertificate` to BunnyClient interface and client (POST with JSON body, returns error only)
- Add `HandleIssueCertificate` proxy handler
- Add `requireAdmin` middleware on route and `ActionIssueCertificate` auth action
- Add mockbunny handler
- Add handler tests (5), client tests (5), integration test (3 auth scenarios), auth test (1), mockbunny tests (3)
- Fix: add `ActionEnableDNSSEC`, `ActionDisableDNSSEC` to `CheckPermissions` admin-only check

## Test plan
- [x] All existing tests pass
- [x] Handler tests: success, invalid zone ID, invalid body, not found, error
- [x] Client tests: success, 404, 401, 400, context canceled
- [x] Integration test: admin succeeds, scoped gets 403, invalid gets 401
- [x] Auth parsing test: issue_certificate action coverage
- [x] MockBunny tests: success, not found, invalid ID
- [x] Coverage: proxy 95.4%, auth 96.2%, bunny 87.3%, mockbunny 93.4%
- [ ] CI pipeline passes

https://claude.ai/code/session_011ZL4TYWQuErtkvnePpHsw8