### PR TITLE
feat: add Get DNS Query Statistics endpoint (admin only)

### DIFF
--- a/internal/auth/actions.go
+++ b/internal/auth/actions.go
@@ -24,6 +24,7 @@ var (
 	exportRecordsPattern     = regexp.MustCompile(`^/dnszone/(\d+)/export/?$`)
 	dnssecPattern            = regexp.MustCompile(`^/dnszone/(\d+)/dnssec/?$`)
 	issueCertificatePattern  = regexp.MustCompile(`^/dnszone/(\d+)/certificate/issue/?$`)
+	statisticsPattern        = regexp.MustCompile(`^/dnszone/(\d+)/statistics/?$`)
 )
 
 // ParseRequest extracts action, zone ID, and record type from HTTP request.
@@ -104,6 +105,13 @@ func ParseRequest(r *http.Request) (*Request, error) {
 		if matches := exportRecordsPattern.FindStringSubmatch(path); matches != nil {
 			zoneID, _ := strconv.ParseInt(matches[1], 10, 64) //nolint:errcheck // regex ensures valid number
 			return &Request{Action: ActionExportRecords, ZoneID: zoneID}, nil
+		}
+		// GET /dnszone/{id}/statistics - query statistics (admin only)
+		if r.Method == http.MethodGet {
+			if matches := statisticsPattern.FindStringSubmatch(path); matches != nil {
+				zoneID, _ := strconv.ParseInt(matches[1], 10, 64) //nolint:errcheck // regex ensures valid number
+				return &Request{Action: ActionGetStatistics, ZoneID: zoneID}, nil
+			}
 		}
 	}
 

--- a/internal/auth/actions_test.go
+++ b/internal/auth/actions_test.go
@@ -137,6 +137,13 @@ func TestParseRequest(t *testing.T) {
 			wantZoneID: 123,
 		},
 		{
+			name:       "get statistics",
+			method:     "GET",
+			path:       "/dnszone/123/statistics",
+			wantAction: ActionGetStatistics,
+			wantZoneID: 123,
+		},
+		{
 			name:    "invalid path",
 			method:  "GET",
 			path:    "/invalid",

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -48,6 +48,8 @@ const (
 	ActionDisableDNSSEC Action = "disable_dnssec"
 	// ActionIssueCertificate issues a wildcard SSL certificate (admin only).
 	ActionIssueCertificate Action = "issue_certificate"
+	// ActionGetStatistics retrieves DNS query statistics (admin only).
+	ActionGetStatistics Action = "get_statistics"
 )
 
 // Errors for authentication and authorization failures.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -153,7 +153,7 @@ func (m *Authenticator) CheckPermissions(next http.Handler) http.Handler {
 			return
 		}
 
-		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords || req.Action == ActionEnableDNSSEC || req.Action == ActionDisableDNSSEC || req.Action == ActionIssueCertificate {
+		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords || req.Action == ActionEnableDNSSEC || req.Action == ActionDisableDNSSEC || req.Action == ActionIssueCertificate || req.Action == ActionGetStatistics {
 			writeJSONErrorWithCode(w, http.StatusForbidden, "admin_required", "This endpoint requires an admin token.")
 			return
 		}

--- a/internal/bunny/types.go
+++ b/internal/bunny/types.go
@@ -144,3 +144,12 @@ type DNSSECResponse struct {
 	DigestType   string `json:"DigestType"`
 	PublicKey    string `json:"PublicKey"`
 }
+
+// ZoneStatisticsResponse represents DNS query statistics for a zone.
+type ZoneStatisticsResponse struct {
+	TotalQueriesServed       int64            `json:"TotalQueriesServed"`
+	QueriesServedChart       map[string]int64 `json:"QueriesServedChart"`
+	NormalQueriesServedChart map[string]int64 `json:"NormalQueriesServedChart"`
+	SmartQueriesServedChart  map[string]int64 `json:"SmartQueriesServedChart"`
+	QueriesByTypeChart       map[string]int64 `json:"QueriesByTypeChart"`
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -45,6 +45,8 @@ type BunnyClient interface {
 	DisableDNSSEC(ctx context.Context, zoneID int64) (*bunny.DNSSECResponse, error)
 	// IssueCertificate triggers issuance of a wildcard SSL certificate.
 	IssueCertificate(ctx context.Context, zoneID int64, domain string) error
+	// GetZoneStatistics retrieves DNS query statistics for a zone.
+	GetZoneStatistics(ctx context.Context, zoneID int64, dateFrom, dateTo string) (*bunny.ZoneStatisticsResponse, error)
 	// AddRecord creates a new DNS record in the specified zone.
 	AddRecord(ctx context.Context, zoneID int64, req *bunny.AddRecordRequest) (*bunny.Record, error)
 
@@ -494,6 +496,36 @@ func (h *Handler) HandleIssueCertificate(w http.ResponseWriter, r *http.Request)
 	h.logger.Info("issue certificate", "zone_id", zoneID, "domain", req.Domain)
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// HandleGetStatistics retrieves DNS query statistics for a zone.
+// GET /dnszone/{zoneID}/statistics
+// Admin only — statistics are outside the record-level permission model.
+func (h *Handler) HandleGetStatistics(w http.ResponseWriter, r *http.Request) {
+	zoneIDStr := chi.URLParam(r, "zoneID")
+	if zoneIDStr == "" {
+		writeError(w, http.StatusBadRequest, "missing zone ID")
+		return
+	}
+
+	zoneID, err := strconv.ParseInt(zoneIDStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid zone ID")
+		return
+	}
+
+	dateFrom := r.URL.Query().Get("dateFrom")
+	dateTo := r.URL.Query().Get("dateTo")
+
+	result, err := h.client.GetZoneStatistics(r.Context(), zoneID, dateFrom, dateTo)
+	if err != nil {
+		handleBunnyError(w, err)
+		return
+	}
+
+	h.logger.Info("get statistics", "zone_id", zoneID)
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // HandleListRecords lists all DNS records for a zone.

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1385,3 +1385,57 @@ func TestIntegration_IssueCertificate_AdminOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_GetStatistics_AdminOnly(t *testing.T) {
+	t.Parallel()
+	mockServer := mockbunny.New()
+	defer mockServer.Close()
+
+	zoneID := mockServer.AddZone("example.com")
+
+	db, err := storage.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+
+	_, err = db.CreateAdminToken(context.Background(), "admin-stats", "admin-stats-token")
+	if err != nil {
+		t.Fatalf("failed to create admin token: %v", err)
+	}
+
+	scopedToken := "scoped-stats-token"
+	scopedHash := sha256.Sum256([]byte(scopedToken))
+	_, err = db.CreateToken(context.Background(), "scoped-stats", false, hex.EncodeToString(scopedHash[:]))
+	if err != nil {
+		t.Fatalf("failed to create scoped token: %v", err)
+	}
+
+	client := bunny.NewClient("test-key", bunny.WithBaseURL(mockServer.URL()))
+	handler := NewHandler(client, testLogger())
+	bootstrapService := auth.NewBootstrapService(db, "master-key")
+	authenticator := auth.NewAuthenticator(db, bootstrapService)
+	router := NewRouter(handler, authenticator.Authenticate, testLogger())
+
+	tests := []struct {
+		name       string
+		token      string
+		wantStatus int
+	}{
+		{"admin token succeeds", "admin-stats-token", http.StatusOK},
+		{"scoped token gets 403", scopedToken, http.StatusForbidden},
+		{"invalid token gets 401", "invalid-token", http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/dnszone/%d/statistics", zoneID), nil)
+			req.Header.Set("AccessKey", tt.token)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d (body: %s)", tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -30,6 +30,7 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	r.With(requireAdmin).Post("/dnszone/{zoneID}/dnssec", handler.HandleEnableDNSSEC)
 	r.With(requireAdmin).Delete("/dnszone/{zoneID}/dnssec", handler.HandleDisableDNSSEC)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}/certificate/issue", handler.HandleIssueCertificate)
+	r.With(requireAdmin).Get("/dnszone/{zoneID}/statistics", handler.HandleGetStatistics)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}", handler.HandleUpdateZone)
 	r.Get("/dnszone/{zoneID}", handler.HandleGetZone)
 	r.Delete("/dnszone/{zoneID}", handler.HandleDeleteZone)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -77,6 +77,7 @@ func New() *Server {
 		r.Post("/dnszone/{id}/dnssec", server.handleEnableDNSSEC)
 		r.Delete("/dnszone/{id}/dnssec", server.handleDisableDNSSEC)
 		r.Post("/dnszone/{id}/certificate/issue", server.handleIssueCertificate)
+		r.Get("/dnszone/{id}/statistics", server.handleGetStatistics)
 		r.Post("/dnszone/{id}", server.handleUpdateZone)
 		r.Put("/dnszone/{zoneId}/records", server.handleAddRecord)
 		r.Post("/dnszone/{zoneId}/records/{id}", server.handleUpdateRecord)


### PR DESCRIPTION
## Summary
- Add `GET /dnszone/{zoneID}/statistics` endpoint that returns DNS query statistics with time-series charts
- Admin-only access (defense-in-depth: `requireAdmin` + `CheckPermissions`)
- Forwards optional `dateFrom`/`dateTo` query parameters to bunny.net API
- Returns `ZoneStatisticsResponse` with `TotalQueriesServed`, `QueriesServedChart`, `NormalQueriesServedChart`, `SmartQueriesServedChart`, `QueriesByTypeChart`

Closes #243

## Changes
- Add `ZoneStatisticsResponse` type with map-based time-series charts
- Add `GetZoneStatistics` to BunnyClient interface and client (GET with query params)
- Add `HandleGetStatistics` proxy handler with query parameter forwarding
- Add `requireAdmin` middleware on route and `ActionGetStatistics` auth action
- Add mockbunny handler with sample statistics data
- Add handler tests (5), client tests (5), integration test (3 auth scenarios), auth test (1), mockbunny tests (3)

## Test plan
- [x] All existing tests pass
- [x] Handler tests: success, query params forwarding, invalid zone ID, not found, error
- [x] Client tests: success with params, success without params, 404, 401, context canceled
- [x] Integration test: admin succeeds, scoped gets 403, invalid gets 401
- [x] Coverage: proxy 95.1%, auth 96.3%, bunny 87.5%, mockbunny 93.5%
- [ ] CI pipeline passes

https://claude.ai/code/session_011ZL4TYWQuErtkvnePpHsw8