### PR TITLE
Add Trigger DNS Scan and Get Scan Result endpoints

### DIFF
--- a/internal/auth/actions_test.go
+++ b/internal/auth/actions_test.go
@@ -144,6 +144,20 @@ func TestParseRequest(t *testing.T) {
 			wantZoneID: 123,
 		},
 		{
+			name:       "trigger DNS scan",
+			method:     "POST",
+			path:       "/dnszone/123/recheckdns",
+			wantAction: ActionTriggerDNSScan,
+			wantZoneID: 123,
+		},
+		{
+			name:       "get DNS scan result",
+			method:     "GET",
+			path:       "/dnszone/123/recheckdns",
+			wantAction: ActionGetDNSScanResult,
+			wantZoneID: 123,
+		},
+		{
 			name:    "invalid path",
 			method:  "GET",
 			path:    "/invalid",

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -50,6 +50,10 @@ const (
 	ActionIssueCertificate Action = "issue_certificate"
 	// ActionGetStatistics retrieves DNS query statistics (admin only).
 	ActionGetStatistics Action = "get_statistics"
+	// ActionTriggerDNSScan triggers a DNS record scan (admin only).
+	ActionTriggerDNSScan Action = "trigger_dns_scan"
+	// ActionGetDNSScanResult retrieves DNS scan results (admin only).
+	ActionGetDNSScanResult Action = "get_dns_scan_result"
 )
 
 // Errors for authentication and authorization failures.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -153,7 +153,7 @@ func (m *Authenticator) CheckPermissions(next http.Handler) http.Handler {
 			return
 		}
 
-		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords || req.Action == ActionEnableDNSSEC || req.Action == ActionDisableDNSSEC || req.Action == ActionIssueCertificate || req.Action == ActionGetStatistics {
+		if req.Action == ActionUpdateZone || req.Action == ActionCreateZone || req.Action == ActionCheckAvailability || req.Action == ActionImportRecords || req.Action == ActionExportRecords || req.Action == ActionEnableDNSSEC || req.Action == ActionDisableDNSSEC || req.Action == ActionIssueCertificate || req.Action == ActionGetStatistics || req.Action == ActionTriggerDNSScan || req.Action == ActionGetDNSScanResult {
 			writeJSONErrorWithCode(w, http.StatusForbidden, "admin_required", "This endpoint requires an admin token.")
 			return
 		}

--- a/internal/bunny/types.go
+++ b/internal/bunny/types.go
@@ -153,3 +153,16 @@ type ZoneStatisticsResponse struct {
 	SmartQueriesServedChart  map[string]int64 `json:"SmartQueriesServedChart"`
 	QueriesByTypeChart       map[string]int64 `json:"QueriesByTypeChart"`
 }
+
+// DNSScanResult represents the result of a DNS record scan.
+type DNSScanResult struct {
+	Records []DNSScanRecord `json:"Records"`
+}
+
+// DNSScanRecord represents a single record found during a DNS scan.
+type DNSScanRecord struct {
+	Type  int    `json:"Type"`
+	Name  string `json:"Name"`
+	Value string `json:"Value"`
+	TTL   int32  `json:"Ttl"`
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -31,6 +31,8 @@ func NewRouter(handler *Handler, authMiddleware func(http.Handler) http.Handler,
 	r.With(requireAdmin).Delete("/dnszone/{zoneID}/dnssec", handler.HandleDisableDNSSEC)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}/certificate/issue", handler.HandleIssueCertificate)
 	r.With(requireAdmin).Get("/dnszone/{zoneID}/statistics", handler.HandleGetStatistics)
+	r.With(requireAdmin).Post("/dnszone/{zoneID}/recheckdns", handler.HandleTriggerScan)
+	r.With(requireAdmin).Get("/dnszone/{zoneID}/recheckdns", handler.HandleGetScanResult)
 	r.With(requireAdmin).Post("/dnszone/{zoneID}", handler.HandleUpdateZone)
 	r.Get("/dnszone/{zoneID}", handler.HandleGetZone)
 	r.Delete("/dnszone/{zoneID}", handler.HandleDeleteZone)

--- a/internal/testutil/mockbunny/server.go
+++ b/internal/testutil/mockbunny/server.go
@@ -78,6 +78,8 @@ func New() *Server {
 		r.Delete("/dnszone/{id}/dnssec", server.handleDisableDNSSEC)
 		r.Post("/dnszone/{id}/certificate/issue", server.handleIssueCertificate)
 		r.Get("/dnszone/{id}/statistics", server.handleGetStatistics)
+		r.Post("/dnszone/{id}/recheckdns", server.handleTriggerScan)
+		r.Get("/dnszone/{id}/recheckdns", server.handleGetScanResult)
 		r.Post("/dnszone/{id}", server.handleUpdateZone)
 		r.Put("/dnszone/{zoneId}/records", server.handleAddRecord)
 		r.Post("/dnszone/{zoneId}/records/{id}", server.handleUpdateRecord)


### PR DESCRIPTION
## Summary
- Implements `POST /dnszone/{zoneID}/recheckdns` to trigger a DNS record scan (admin-only)
- Implements `GET /dnszone/{zoneID}/recheckdns` to retrieve scan results (admin-only)
- Fixes regex bug in `recheckDNSPattern` (`(d+)` → `(\d+)`)

Closes #244
Closes #245

## Changes
- **bunny/types.go**: Added `DNSScanResult` and `DNSScanRecord` types
- **bunny/client.go**: Added `TriggerDNSScan` and `GetDNSScanResult` client methods
- **proxy/handler.go**: Added `HandleTriggerScan` and `HandleGetScanResult` handlers, updated `BunnyClient` interface
- **proxy/router.go**: Registered POST and GET routes at `/dnszone/{zoneID}/recheckdns` with `requireAdmin`
- **auth/auth.go**: Added `ActionTriggerDNSScan` and `ActionGetDNSScanResult` actions
- **auth/actions.go**: Added `recheckDNSPattern` regex and `ParseRequest` cases for both endpoints; fixed regex backslash bug
- **auth/middleware.go**: Added both actions to admin-only check in `CheckPermissions`
- **mockbunny/**: Added `handleTriggerScan` and `handleGetScanResult` mock handlers with route registration
- Full test coverage across all packages (auth 96.4%, bunny 87.4%, proxy 94.4%, mockbunny 93.9%)

## Test plan
- [x] Unit tests for bunny client methods (success, not found, server error)
- [x] Unit tests for proxy handlers (success, not found, client error)
- [x] Unit tests for auth ParseRequest (trigger scan, get scan result)
- [x] Integration tests verifying admin-only access
- [x] MockBunny handler tests
- [x] All CI checks pass (lint, security, test, build, docker, E2E mock)

https://claude.ai/code/session_011ZL4TYWQuErtkvnePpHsw8