### PR TITLE
Fix .gitignore pattern to allow internal/testutil/mockbunny

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.so
 *.dylib
 bunny-api-proxy
-mockbunny
+/mockbunny
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Changed 'mockbunny' pattern to '/mockbunny' to only match the compiled binary at the repository root, not the mockbunny directory at internal/testutil/mockbunny. The pattern 'mockbunny' was too broad and prevented adding files in the mockbunny test utility directory.

https://claude.ai/code/session_01DyV4ZYaHxFLuyumfRqEPGM