### PR TITLE
ci: optimize CI/CD pipeline to reduce cost and redundancy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,39 @@ on:
       - '.gitignore'
       - '.github/workflows/explore-api.yml'
 
-# Deduplicate: push and pull_request for the same branch share a group.
-# When both fire for the same commit, only one runs.
+# Cancel in-progress CI for the same PR/branch when new commits are pushed
 concurrency:
-  group: ci-${{ github.head_ref || github.ref_name }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Skip push-triggered runs when a PR exists (PR-triggered run handles it)
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - name: Check for open PR on push
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REF_NAME" --state open --json number --jq length)
+            if [ "$PR_COUNT" -gt 0 ]; then
+              echo "should_skip=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping push CI — PR exists, PR-triggered CI will run instead"
+              exit 0
+            fi
+          fi
+          echo "should_skip=false" >> "$GITHUB_OUTPUT"
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [preflight]
+    if: needs.preflight.outputs.should_skip != 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -50,6 +73,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [preflight]
+    if: needs.preflight.outputs.should_skip != 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -80,6 +105,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    needs: [preflight]
+    if: needs.preflight.outputs.should_skip != 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Optimizes the CI pipeline to eliminate redundant runs, reduce runner minutes, and strengthen the merge gate — without compromising quality.

- **Preflight deduplication**: Push-triggered CI self-skips when an open PR exists for the branch, so only the PR-triggered run (with real API E2E) executes. Eliminates the double-trigger problem (~22 redundant full pipelines in the last 200 runs).
- **Lightweight push-to-main**: After merge, only test+lint+security run (~1 min) instead of the full build/docker/e2e pipeline (~8 min) that already passed during the PR.
- **Parallel E2E tests**: Mock and real API E2E tests now run in parallel on separate runners instead of sequentially, saving ~2-3 min per PR.
- **Concurrency cancellation**: Stale CI runs are cancelled when new commits are pushed to the same PR.
- **Removed job-level concurrency group** from real API E2E tests that was silently dropping queued jobs.

Estimated savings: ~50% reduction in CI runner minutes.

## Branch protection

Required status checks (`Test` + `Lint`) have been added to the main branch ruleset via the GitHub UI (not in this PR).

## Test plan

- [ ] Push to `claude/**` branch without PR → full pipeline runs (test, lint, security, build, docker, e2e-mock)
- [ ] Create PR → PR-triggered full pipeline runs including real API E2E
- [ ] Push to branch with open PR → push CI skips (preflight detects PR), PR CI runs with real API
- [ ] Merge to main → only test, lint, security run (build/docker/e2e skip)
- [ ] Rapid pushes to same PR → previous run cancelled, latest runs

https://claude.ai/code/session_011MEAKttNf4Uh6tC97Bvv24