### PR TITLE
Fix #299: Drop ALL Linux capabilities in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,14 +57,12 @@ services:
         max-size: "10m"
         max-file: "3"
 
-    # Security: Drop unnecessary Linux capabilities
-    # CAP_NET_RAW: prevents raw socket access
-    # CAP_NET_ADMIN: prevents network administration
-    # CAP_SYS_ADMIN: prevents system-level operations
+    # Security: Drop all Linux capabilities (proxy requires none)
+    # Following least-privilege principle: drop ALL, add back only what's needed
+    # The proxy is a simple HTTP server (read/write SQLite, make HTTP requests)
+    # and requires zero special Linux capabilities
     cap_drop:
-      - CAP_NET_RAW
-      - CAP_NET_ADMIN
-      - CAP_SYS_ADMIN
+      - ALL
 
     # Security: Read-only root filesystem
     # Prevents accidental or malicious modification of the image


### PR DESCRIPTION
## Summary
Improves container security by following the least-privilege principle: drop ALL Linux capabilities and add back only what's needed. The proxy requires zero special capabilities.

## Changes
- Modified `docker-compose.yml` to replace selective `cap_drop` (CAP_NET_RAW, CAP_NET_ADMIN, CAP_SYS_ADMIN) with `cap_drop: [ALL]`
- Updated comments to document the security rationale
- Application functionality validated via Docker Build and E2E tests in CI

## Rationale
The proxy is a simple HTTP server that:
- Listens on a TCP port (requires no special capabilities)
- Reads/writes SQLite database (requires no special capabilities)
- Makes outbound HTTP requests (requires no special capabilities)

Dropping all capabilities reduces the attack surface if code execution occurs inside the container, while the application continues to function normally.

## Testing
- ✓ Docker Build successful with new settings
- ✓ E2E tests (Mock) passed
- ✓ All CI validations passed

Fixes #299

https://claude.ai/code/session_013jVQraAbEHdxFkoHUcm53e