### PR TITLE
Fix env var race conditions in main_test.go by removing t.Parallel()

### DIFF
--- a/cmd/bunny-api-proxy/main_test.go
+++ b/cmd/bunny-api-proxy/main_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestHealthHandler(t *testing.T) {
-	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
@@ -40,7 +39,6 @@ func TestHealthHandler(t *testing.T) {
 }
 
 func TestReadyHandler(t *testing.T) {
-	t.Parallel()
 	// Create a temporary in-memory storage for testing
 	store, err := storage.New(":memory:")
 	if err != nil {
@@ -69,7 +67,6 @@ func TestReadyHandler(t *testing.T) {
 }
 
 func TestReadyHandlerWithClosedStorage(t *testing.T) {
-	t.Parallel()
 	// Create a storage and close it to simulate database unavailability
 	store, err := storage.New(":memory:")
 	if err != nil {
@@ -191,7 +188,6 @@ func TestInitializeComponentsWithDebugLogLevel(t *testing.T) {
 // is properly wired up in main.go - the actual logging behavior is tested in
 // internal/bunny/logging_transport_test.go and verified in E2E tests.
 func TestInitializeComponentsBunnyClientWithLoggingTransport(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -369,7 +365,6 @@ func TestRunWithInvalidLogLevel(t *testing.T) {
 }
 
 func TestReadyHandlerContextTimeout(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -423,7 +418,6 @@ func BenchmarkReadyHandler(b *testing.B) {
 
 // TestReadyHandlerWithTimeoutContext tests that ready handler respects context timeout
 func TestReadyHandlerWithTimeoutContext(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -452,7 +446,6 @@ func TestReadyHandlerWithTimeoutContext(t *testing.T) {
 
 // TestHealthHandlerContentType validates JSON response format
 func TestHealthHandlerContentType(t *testing.T) {
-	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
@@ -466,7 +459,6 @@ func TestHealthHandlerContentType(t *testing.T) {
 
 // TestReadyHandlerContentType validates JSON response format
 func TestReadyHandlerContentType(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -487,7 +479,6 @@ func TestReadyHandlerContentType(t *testing.T) {
 
 // TestReadyHandlerResponseBody validates response structure
 func TestReadyHandlerResponseBody(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -509,7 +500,6 @@ func TestReadyHandlerResponseBody(t *testing.T) {
 
 // TestHealthHandlerResponseBody validates response structure
 func TestHealthHandlerResponseBody(t *testing.T) {
-	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
@@ -524,7 +514,6 @@ func TestHealthHandlerResponseBody(t *testing.T) {
 
 // TestReadyHandlerErrorResponseFormat validates error response structure
 func TestReadyHandlerErrorResponseFormat(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -552,7 +541,6 @@ func TestReadyHandlerErrorResponseFormat(t *testing.T) {
 
 // TestReadyHandlerStatusOKResponse validates successful response
 func TestReadyHandlerStatusOKResponse(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -572,7 +560,6 @@ func TestReadyHandlerStatusOKResponse(t *testing.T) {
 
 // TestInitializeComponentsWithWarnLogLevel tests debug log level
 func TestInitializeComponentsWithWarnLogLevel(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -611,7 +598,6 @@ func TestInitializeComponentsWithWarnLogLevel(t *testing.T) {
 
 // TestInitializeComponentsWithErrorLogLevel tests error log level
 func TestInitializeComponentsWithErrorLogLevel(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -650,7 +636,6 @@ func TestInitializeComponentsWithErrorLogLevel(t *testing.T) {
 
 // TestInitializeComponentsRouterSetup validates that the main router is properly configured
 func TestInitializeComponentsRouterSetup(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -694,7 +679,6 @@ func TestInitializeComponentsRouterSetup(t *testing.T) {
 
 // TestInitializeComponentsReadyEndpoint validates that ready endpoint works
 func TestInitializeComponentsReadyEndpoint(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -738,7 +722,6 @@ func TestInitializeComponentsReadyEndpoint(t *testing.T) {
 
 // TestInitializeComponentsValidatorCreated validates validator is created
 func TestInitializeComponentsValidatorCreated(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -774,7 +757,6 @@ func TestInitializeComponentsValidatorCreated(t *testing.T) {
 
 // TestInitializeComponentsStorageCreated validates storage is created and working
 func TestInitializeComponentsStorageCreated(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -818,7 +800,6 @@ func TestInitializeComponentsStorageCreated(t *testing.T) {
 
 // TestInitializeComponentsBunnyClientCreated validates bunny client is created
 func TestInitializeComponentsBunnyClientCreated(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -857,7 +838,6 @@ func TestInitializeComponentsBunnyClientCreated(t *testing.T) {
 
 // TestMainServerStartAndHealthCheck tests that the server can start and respond to health checks
 func TestMainServerStartAndHealthCheck(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -914,7 +894,6 @@ func TestMainServerStartAndHealthCheck(t *testing.T) {
 
 // TestInitializeComponentsAllComponentsNotNil verifies no component is nil
 func TestInitializeComponentsAllComponentsNotNil(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -976,7 +955,6 @@ func TestInitializeComponentsAllComponentsNotNil(t *testing.T) {
 
 // TestInitializeComponentsLogLevelVariantWorks validates the log level can be changed
 func TestInitializeComponentsLogLevelVariantWorks(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1053,7 +1031,6 @@ func TestRunWithInvalidDatabasePath(t *testing.T) {
 
 // TestInitializeComponentsWithAllLogLevels tests initialization with multiple log levels
 func TestInitializeComponentsWithInfoLogLevel(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1134,7 +1111,6 @@ func TestInitializeComponentsErrorHandling(t *testing.T) {
 
 // TestReadyHandlerDatabaseConnectivity tests ready handler properly checks database
 func TestReadyHandlerDatabaseConnectivity(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -1160,7 +1136,6 @@ func TestReadyHandlerDatabaseConnectivity(t *testing.T) {
 
 // TestHealthHandlerIsAlwaysOK tests that health handler always returns OK
 func TestHealthHandlerIsAlwaysOK(t *testing.T) {
-	t.Parallel()
 	for i := 0; i < 5; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		w := httptest.NewRecorder()
@@ -1175,7 +1150,6 @@ func TestHealthHandlerIsAlwaysOK(t *testing.T) {
 
 // TestReadyHandlerMultipleCalls tests ready handler can be called multiple times
 func TestReadyHandlerMultipleCalls(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -1198,7 +1172,6 @@ func TestReadyHandlerMultipleCalls(t *testing.T) {
 
 // TestCreateServer tests that the server is created with correct configuration
 func TestCreateServer(t *testing.T) {
-	t.Parallel()
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
 	oldListenAddr := os.Getenv("LISTEN_ADDR")
@@ -1264,7 +1237,6 @@ func TestCreateServer(t *testing.T) {
 
 // TestCreateServerWithDifferentPorts tests server creation with different ports
 func TestCreateServerWithDifferentPorts(t *testing.T) {
-	t.Parallel()
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
 	oldListenAddr := os.Getenv("LISTEN_ADDR")
@@ -1309,7 +1281,6 @@ func TestCreateServerWithDifferentPorts(t *testing.T) {
 
 // TestServerShutdownTimeoutConstant validates the shutdown timeout is set correctly
 func TestServerShutdownTimeoutConstant(t *testing.T) {
-	t.Parallel()
 	expectedTimeout := serverShutdownTimeout
 	if expectedTimeout != 30*time.Second {
 		t.Errorf("server shutdown timeout should be 30 seconds, got %v", expectedTimeout)
@@ -1318,7 +1289,6 @@ func TestServerShutdownTimeoutConstant(t *testing.T) {
 
 // TestVersionConstant validates the version string is set
 func TestVersionConstant(t *testing.T) {
-	t.Parallel()
 	if version == "" {
 		t.Error("version constant should not be empty")
 	}
@@ -1329,7 +1299,6 @@ func TestVersionConstant(t *testing.T) {
 
 // TestServerWithReadyAndHealthEndpoints tests that both endpoints are properly mounted
 func TestServerWithReadyAndHealthEndpoints(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1382,7 +1351,6 @@ func TestServerWithReadyAndHealthEndpoints(t *testing.T) {
 
 // TestHealthHandlerResponseHeaders validates response headers are correct
 func TestHealthHandlerResponseHeaders(t *testing.T) {
-	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
@@ -1401,7 +1369,6 @@ func TestHealthHandlerResponseHeaders(t *testing.T) {
 
 // TestReadyHandlerResponseHeaders validates response headers are correct
 func TestReadyHandlerResponseHeaders(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create storage: %v", err)
@@ -1422,7 +1389,6 @@ func TestReadyHandlerResponseHeaders(t *testing.T) {
 
 // TestCreateServerHandlerIsSet tests that server handler is properly assigned
 func TestCreateServerHandlerIsSet(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1470,7 +1436,6 @@ func TestCreateServerHandlerIsSet(t *testing.T) {
 
 // TestRunComponentInitializationPath tests the full run() component initialization path
 func TestRunComponentInitializationPath(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1527,7 +1492,6 @@ func TestRunComponentInitializationPath(t *testing.T) {
 
 // TestInitializeComponentsLoggerDefaultLevel tests that logger is set as default
 func TestInitializeComponentsLoggerDefaultLevel(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1568,7 +1532,6 @@ func TestInitializeComponentsLoggerDefaultLevel(t *testing.T) {
 
 // TestCreateServerTimeouts verifies timeout values are correctly set
 func TestCreateServerTimeouts(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1624,7 +1587,6 @@ func TestCreateServerTimeouts(t *testing.T) {
 
 // TestStartServerAndWaitForShutdownWithServerError tests server shutdown when ListenAndServe returns error
 func TestStartServerAndWaitForShutdownWithServerError(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1674,7 +1636,6 @@ func TestStartServerAndWaitForShutdownWithServerError(t *testing.T) {
 
 // TestStorageCloseError tests that storage close errors are logged
 func TestStorageCloseError(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1714,7 +1675,6 @@ func TestStorageCloseError(t *testing.T) {
 
 // TestInitializeComponentsLoggingLevel tests that log level parsing works correctly
 func TestInitializeComponentsLoggingLevelDebug(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1754,7 +1714,6 @@ func TestInitializeComponentsLoggingLevelDebug(t *testing.T) {
 
 // TestCreateServerIsServerInitialized tests that createServer initializes all fields
 func TestCreateServerIsServerInitialized(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1813,7 +1772,6 @@ func TestCreateServerIsServerInitialized(t *testing.T) {
 
 // TestRunCompleteFlow tests the full run() function with all components
 func TestRunCompleteFlow(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -1880,7 +1838,6 @@ func TestRunCompleteFlow(t *testing.T) {
 
 // TestConfigLoadsWithDefaults tests that config loads successfully with all defaults
 func TestConfigLoadsWithDefaults(t *testing.T) {
-	t.Parallel()
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
 	oldListenAddr := os.Getenv("LISTEN_ADDR")
@@ -1927,7 +1884,6 @@ func TestConfigLoadsWithDefaults(t *testing.T) {
 
 // TestHealthHandlerAlwaysSucceeds tests that health endpoint is always OK
 func TestHealthHandlerAlwaysReturnsOK(t *testing.T) {
-	t.Parallel()
 	for i := 0; i < 10; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		w := httptest.NewRecorder()
@@ -1942,7 +1898,6 @@ func TestHealthHandlerAlwaysReturnsOK(t *testing.T) {
 
 // TestReadyHandlerMultipleRequestsConsistency tests that ready endpoint behaves consistently
 func TestReadyHandlerMultipleRequestsConsistency(t *testing.T) {
-	t.Parallel()
 	store, err := storage.New(":memory:")
 	if err != nil {
 		t.Fatalf("failed to create test storage: %v", err)
@@ -1965,7 +1920,6 @@ func TestReadyHandlerMultipleRequestsConsistency(t *testing.T) {
 
 // TestRunWithHealthEndpoint tests that the server correctly exposes the health endpoint
 func TestRunWithHealthEndpoint(t *testing.T) {
-	t.Parallel()
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
 	oldListenAddr := os.Getenv("LISTEN_ADDR")
@@ -2041,7 +1995,6 @@ func TestRunWithHealthEndpoint(t *testing.T) {
 
 // TestInitializeComponentsCreateAllRouters tests that all routers are created
 func TestInitializeComponentsCreateAllRouters(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2109,7 +2062,6 @@ func TestInitializeComponentsCreateAllRouters(t *testing.T) {
 
 // TestRunInitializeComponentsWithInvalidLogLevel tests that initializeComponents fails with invalid log level
 func TestRunInitializeComponentsWithInvalidLogLevel(t *testing.T) {
-	t.Parallel()
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
 
@@ -2145,7 +2097,6 @@ func TestRunInitializeComponentsWithInvalidLogLevel(t *testing.T) {
 
 // TestInitializeComponentsWithErrorPath tests error handling in initialization
 func TestInitializeComponentsValidation(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2186,7 +2137,6 @@ func TestInitializeComponentsValidation(t *testing.T) {
 
 // TestCreateServerAddrFormatting tests correct address formatting
 func TestCreateServerAddrFormatting(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		addr     string
 		expected string
@@ -2313,7 +2263,6 @@ func TestStartActualServer(t *testing.T) {
 }
 
 func TestRunInitializeComponentsInvalidLogLevel(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2355,7 +2304,6 @@ func TestRunInitializeComponentsInvalidLogLevel(t *testing.T) {
 
 // TestStartServerAndWaitForShutdownServerStartupError tests server startup error handling
 func TestStartServerAndWaitForShutdownServerStartupError(t *testing.T) {
-	t.Parallel()
 	// Create a test logger
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
@@ -2386,7 +2334,6 @@ func TestStartServerAndWaitForShutdownServerStartupError(t *testing.T) {
 
 // TestStartServerAndWaitForShutdownGracefulSignalShutdown tests graceful shutdown when receiving SIGTERM signal
 func TestStartServerAndWaitForShutdownGracefulSignalShutdown(t *testing.T) {
-	t.Parallel()
 	// Create a test logger with a buffer to capture logs
 	var logBuffer bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -2444,7 +2391,6 @@ func TestStartServerAndWaitForShutdownGracefulSignalShutdown(t *testing.T) {
 
 // TestDoHealthCheckSuccess tests that doHealthCheck returns 0 when server returns 200 OK
 func TestDoHealthCheckSuccess(t *testing.T) {
-	t.Parallel()
 	// Create a test server that returns 200 OK
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -2460,7 +2406,6 @@ func TestDoHealthCheckSuccess(t *testing.T) {
 
 // TestDoHealthCheckNon200Status tests that doHealthCheck returns 1 when server returns non-200 status
 func TestDoHealthCheckNon200Status(t *testing.T) {
-	t.Parallel()
 	// Create a test server that returns 503 Service Unavailable
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -2476,7 +2421,6 @@ func TestDoHealthCheckNon200Status(t *testing.T) {
 
 // TestDoHealthCheckConnectionError tests that doHealthCheck returns 1 when connection fails
 func TestDoHealthCheckConnectionError(t *testing.T) {
-	t.Parallel()
 	// Use an invalid URL that will fail to connect
 	result := doHealthCheck("http://localhost:99999/health")
 	if result != 1 {
@@ -2486,7 +2430,6 @@ func TestDoHealthCheckConnectionError(t *testing.T) {
 
 // TestDoHealthCheck404Status tests that doHealthCheck returns 1 when server returns 404
 func TestDoHealthCheck404Status(t *testing.T) {
-	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -2500,7 +2443,6 @@ func TestDoHealthCheck404Status(t *testing.T) {
 
 // TestDoHealthCheck500Status tests that doHealthCheck returns 1 when server returns 500
 func TestDoHealthCheck500Status(t *testing.T) {
-	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -2514,7 +2456,6 @@ func TestDoHealthCheck500Status(t *testing.T) {
 
 // TestRunHealthCheckUsesCorrectURL tests that runHealthCheck calls the correct URL
 func TestRunHealthCheckUsesCorrectURL(t *testing.T) {
-	t.Parallel()
 	// This test verifies the function exists and returns 1 when no server is running
 	// on localhost:8080 (which should be the case during unit tests)
 	result := runHealthCheck()
@@ -2525,7 +2466,6 @@ func TestRunHealthCheckUsesCorrectURL(t *testing.T) {
 
 // TestMainRouterDoesNotHaveMetricsEndpoint verifies that /metrics is not on the main router
 func TestMainRouterDoesNotHaveMetricsEndpoint(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2571,7 +2511,6 @@ func TestMainRouterDoesNotHaveMetricsEndpoint(t *testing.T) {
 
 // TestMetricsRouterHasMetricsEndpoint verifies that /metrics is accessible on the metrics router
 func TestMetricsRouterHasMetricsEndpoint(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2616,7 +2555,6 @@ func TestMetricsRouterHasMetricsEndpoint(t *testing.T) {
 
 // TestMetricsListenAddrDefaultValue verifies that metrics listen address defaults to localhost:9090
 func TestMetricsListenAddrDefaultValue(t *testing.T) {
-	t.Parallel()
 
 	oldMetricsAddr := os.Getenv("METRICS_LISTEN_ADDR")
 	defer func() {
@@ -2664,7 +2602,6 @@ func TestMetricsListenAddrCustomValue(t *testing.T) {
 
 // TestCreateMetricsServer verifies metrics server is created correctly
 func TestCreateMetricsServer(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2730,7 +2667,6 @@ func TestCreateMetricsServer(t *testing.T) {
 
 // TestInitializeComponentsMetricsRouter verifies metrics router is created
 func TestInitializeComponentsMetricsRouter(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2838,7 +2774,6 @@ func TestStartServersAndWaitForShutdownGraceful(t *testing.T) {
 
 // TestRunWithMetricsServerConfigured tests run() with custom metrics address
 func TestRunWithMetricsServerConfigured(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2893,7 +2828,6 @@ func TestRunWithMetricsServerConfigured(t *testing.T) {
 
 // TestCreateMetricsServerWithDifferentAddresses tests metrics server with various addresses
 func TestCreateMetricsServerWithDifferentAddresses(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2941,7 +2875,6 @@ func TestCreateMetricsServerWithDifferentAddresses(t *testing.T) {
 
 // TestInitializeComponentsWithMetricsRouterNotNil verifies metrics router field
 func TestInitializeComponentsWithMetricsRouterNotNil(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -2981,7 +2914,6 @@ func TestInitializeComponentsWithMetricsRouterNotNil(t *testing.T) {
 
 // TestServerComponentsHasMetricsRouter verifies serverComponents struct has metricsRouter
 func TestServerComponentsHasMetricsRouter(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")
@@ -3033,7 +2965,6 @@ func TestServerComponentsHasMetricsRouter(t *testing.T) {
 
 // TestCreateMetricsServerPreservesTimeout tests metrics server timeout configuration
 func TestCreateMetricsServerPreservesTimeout(t *testing.T) {
-	t.Parallel()
 
 	cfg := &config.Config{
 		MetricsListenAddr: ":9090",
@@ -3056,7 +2987,6 @@ func TestCreateMetricsServerPreservesTimeout(t *testing.T) {
 
 // TestInitializeComponentsProducesValidMetricsHandler tests metrics handler works
 func TestInitializeComponentsProducesValidMetricsHandler(t *testing.T) {
-	t.Parallel()
 
 	oldDatabasePath := os.Getenv("DATABASE_PATH")
 	oldLogLevel := os.Getenv("LOG_LEVEL")


### PR DESCRIPTION
## Summary

Fixes intermittent test failures caused by race conditions when multiple tests in `cmd/bunny-api-proxy/main_test.go` modify process-global environment variables while running in parallel.

## Problem

Tests were using both `t.Parallel()` and `os.Setenv()`/`os.Unsetenv()` to modify environment variables. While `t.Setenv` prevents parallel execution within a single test, `os.Setenv()` does not. This allowed concurrent tests to interfere with each other's environment variable state, causing hard-to-diagnose intermittent failures on CI.

## Solution

Removed `t.Parallel()` from all 42+ tests in `cmd/bunny-api-proxy/main_test.go` that modify environment variables. Tests now run serially and do not interfere with each other.

## Verification

- ✅ All tests pass with `-race` flag (no race conditions detected)
- ✅ Tests pass reliably under `-count=100` repeated runs (160+ seconds for 100 iterations)
- ✅ All linting checks pass
- ✅ CI pipeline passes all checks (Preflight, Test, Security Scan, Lint)

## Changes

- Removed 70 `t.Parallel()` calls from `cmd/bunny-api-proxy/main_test.go`
- No functional changes to test logic, only removing the parallel execution directives

## Acceptance Criteria Met

- ✅ No test uses both `t.Setenv` and `t.Parallel()`
- ✅ Tests pass reliably under `-count=100` repeated runs
- ✅ Tests pass with `-race` flag

Closes #308

https://claude.ai/code/session_01Um6VAzBoBY3Mbgip8DKS1k