### PR TITLE
Fix hardcoded PROXY_URL localhost:8080 causing port conflicts

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	proxyURL = getEnv("PROXY_URL", "http://localhost:8080")
+	proxyURL = requireEnv("PROXY_URL")
 	adminPassword = getEnv("ADMIN_PASSWORD", "testpassword123")
 
 	// Wait for proxy to be ready

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -21,6 +21,19 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+// requireEnv returns an environment variable or fails with a clear error message.
+// This is used for required configuration like PROXY_URL.
+func requireEnv(key string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	fmt.Fprintf(os.Stderr, "FATAL: required environment variable %s is not set\n", key)
+	fmt.Fprintf(os.Stderr, "Please set %s to the proxy URL (e.g., http://localhost:8080)\n", key)
+	fmt.Fprintf(os.Stderr, "This prevents accidental test failures due to port conflicts on commonly-used ports.\n")
+	os.Exit(1)
+	return "" // unreachable
+}
+
 // waitForService polls a URL until it's healthy or timeout is reached.
 func waitForService(url string, timeout time.Duration) error {
 	client := &http.Client{Timeout: 2 * time.Second}


### PR DESCRIPTION
## Summary
Removes hardcoded default port 8080 from E2E tests and requires explicit PROXY_URL environment variable. This prevents accidental test failures when port 8080 is occupied by another service on the developer's machine.

## Changes
- Added `requireEnv()` helper function to enforce required environment variables with clear error messages
- Updated `TestMain()` to use `requireEnv("PROXY_URL")` instead of `getEnv("PROXY_URL", "http://localhost:8080")`
- Kept `METRICS_URL` optional with default localhost:9090 (used only for optional metrics analysis)
- Error message guides developers when PROXY_URL is not set

## Test Plan
- [x] All unit tests pass
- [x] Code formatting validated (make fmt-check)
- [x] Linting passes (make lint)
- [x] Pre-commit checks pass (make pre-commit-check)
- Waiting for CI pipeline validation

## Acceptance Criteria
- [x] Default hardcoded port 8080 removed (explicit PROXY_URL now required)
- [x] Clear error message when PROXY_URL environment variable is not set

https://claude.ai/code/session_01LbHWsPUGfMQhNREQBqAu9a