### PR TITLE
ci: remove active run cancellation to fix blocked merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   # Deduplicate push vs pull_request runs for the same branch.
   # - Push events: wait 15s for a PR to appear, then skip if one exists.
-  # - PR events: cancel any in-progress push-triggered run for the same branch.
+  # - PR events: proceed normally (no active cancellation to avoid blocked merges).
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
@@ -46,17 +46,6 @@ jobs:
               echo "::notice::Skipping push CI — PR exists, PR-triggered CI will run instead"
               exit 0
             fi
-          fi
-
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            # Cancel any in-progress push-triggered CI runs for this branch (PR run takes priority)
-            BRANCH="${{ github.head_ref }}"
-            echo "Checking for push-triggered runs on branch $BRANCH to cancel..."
-            PUSH_RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --branch "$BRANCH" --event push --workflow ci.yml --json databaseId,status --jq '.[] | select(.status == "in_progress" or .status == "queued") | .databaseId')
-            for RUN_ID in $PUSH_RUNS; do
-              echo "::notice::Cancelling push-triggered run $RUN_ID (PR run takes priority)"
-              gh run cancel "$RUN_ID" --repo "$GITHUB_REPOSITORY" || true
-            done
           fi
 
           echo "should_skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Remove the `gh run cancel` block from the PR preflight job that was actively cancelling push-triggered CI runs
- This fixes the issue where cancelled check statuses blocked PR merges, even when the latest PR-triggered CI passed

## Problem
The PR preflight was running `gh run cancel` on push-triggered CI runs for the same branch. This created "cancelled" check statuses on those runs. GitHub treats "cancelled" as not satisfying required status checks (Test, Lint, E2E Tests), so agents were unable to merge PRs despite the latest CI passing.

Agents reported: *"Both PRs are BLOCKED due to cancelled checks from earlier runs, even though the latest CI runs passed."*

## Fix
Remove the active cancellation entirely and rely on the existing 15s delay approach for push-event deduplication. Trade-off: ~30% of push+PR double-triggers won't be caught (both runs proceed), but no PRs will be blocked by stale cancelled statuses.

The concurrency group (`ci-${{ github.event.pull_request.number || github.ref }}`) still handles same-branch re-push cancellation correctly.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, verify agents can push branches, create PRs, and merge without blocked checks

https://claude.ai/code/session_011MEAKttNf4Uh6tC97Bvv24